### PR TITLE
nightshift/2026-04-03 — overnight shift log

### DIFF
--- a/docs/Nightshift/2026-04-03.md
+++ b/docs/Nightshift/2026-04-03.md
@@ -5,11 +5,11 @@
 **Started**: 16:33
 
 ## Summary
-The shift has started. Reconnaissance is underway and this summary will be rewritten as the overnight run accumulates real fixes and logged issues.
+Short validation run (2 cycles). No code changes were made — both cycles operated in log-only mode. Two issues were identified and logged, both in `nightshift.py`: a **high-severity security issue** where `merge_config()` shallow-updates list fields (allowing user overrides to silently drop default safety paths), and a **medium-severity reliability issue** where `run_command()`'s timeout cannot fire while `readline()` blocks on a hung process. Both require design decisions and are documented below with suggested fixes.
 
 ## Stats
 - Fixes committed: 0
-- Issues logged: 1
+- Issues logged: 2
 - Tests added: 0
 - Files touched: 0
 - Low-impact fixes: 0
@@ -45,8 +45,19 @@ The shift has started. Reconnaissance is underway and this summary will be rewri
 - **Suggested fix**: Deep-merge list fields (`blocked_paths`, `blocked_globs`) by extending the defaults rather than replacing them. Something like: for each key in `loaded`, if both the default and override are lists, use `config[key] = list(set(config[key] + loaded[key]))` instead of a flat `update`. Alternatively, provide explicit `blocked_paths_add` / `blocked_paths_remove` keys for user overrides while preserving defaults.
 - **Why not fixed tonight**: File has recent team activity; also requires a design decision on the merge strategy (extend vs. explicit add/remove keys).
 
+### 2. run_command timeout ineffective when readline blocks on hung process (cycle 2)
+- **Severity**: medium
+- **Category**: Error Handling
+- **Files**: `nightshift.py:168-206`
+- **What I found**: `run_command()` checks whether `timeout_seconds` has elapsed only *after* `process.stdout.readline()` returns (line 169). `readline()` is a blocking call that waits for a full line or pipe close. If the spawned agent process hangs without producing output (e.g., stuck on a network call, deadlocked), `readline()` blocks indefinitely and the timeout check on line 181 is never reached. The timeout only works when the process is actively producing output.
+- **Production impact**: During an overnight run, a hung agent cycle would block the entire Nightshift runner indefinitely instead of being killed after `timeout_seconds`. The runner banner would show "Nightshift Starting" and never progress, consuming the full shift window with no fixes and no log output.
+- **Suggested fix**: Use a non-blocking I/O strategy. Options: (a) use `select.select()` or `selectors` to poll `process.stdout` with a short timeout before calling `readline()`, (b) move the readline loop to a separate thread and join with a timeout from the main thread, or (c) use `signal.alarm` (Unix-only) as a watchdog. Option (b) is the most portable and easiest to reason about.
+- **Why not fixed tonight**: File has recent team activity; the fix requires choosing between I/O strategies with different portability and complexity tradeoffs.
+
 ---
 
 ## Recommendations
 
-- Add patterns and systemic follow-up items here as the shift progresses.
+- **Priority 1 — Fix `merge_config` shallow update** (Logged Issue #1): This is a security-relevant bug. Any user who customizes `.nightshift.json` with `blocked_paths` unknowingly removes all default protections. A one-line deep-merge for list fields would close the gap.
+- **Priority 2 — Fix `run_command` timeout** (Logged Issue #2): A threaded readline approach is the simplest path. Without this, a single hung agent process can stall an entire overnight run.
+- **Consider adding integration tests**: Neither of these bugs would be caught by the current testing strategy (manual `test.sh` runs). A small pytest suite that exercises `merge_config` with override dicts and `run_command` with a deliberately-hanging subprocess would prevent regressions.


### PR DESCRIPTION
## Summary
- Logged 2 issues found during a validation run (log-only mode — baseline verification failed because tests/ wasn't on main yet)
- **merge_config shallow update** — `.nightshift.json` overrides replace default blocked paths instead of extending them (security)
- **run_command timeout race** — readline() blocks so timeout can never fire on a hung process (reliability)

## Shift log
See `docs/Nightshift/2026-04-03.md` for full details and recommendations.