### PR TITLE
feat: post-cycle diff scorer

### DIFF
--- a/.nightshift.json.example
+++ b/.nightshift.json.example
@@ -26,5 +26,6 @@
   "max_files_per_cycle": 12,
   "max_low_impact_fixes_per_shift": 4,
   "stop_after_failed_verifications": 2,
-  "stop_after_empty_cycles": 2
+  "stop_after_empty_cycles": 2,
+  "score_threshold": 3
 }

--- a/docs/changelog/v0.0.3.md
+++ b/docs/changelog/v0.0.3.md
@@ -14,11 +14,17 @@ Improvements to cycle intelligence: config security, timeout reliability, diff s
 
 ## Added
 
+- `[feat]` **Post-cycle diff scorer** — `score_diff()` in `cycle.py` scores each cycle's changes 1-10 based on production impact. Factors: fix category priority (Security=8, Error Handling=6, Tests=6, etc.), diff content analysis (regex patterns for security/error keywords), test file bonus (+1), category breadth bonus (+1 for multi-category cycles). Cycles scoring below `score_threshold` (default 3) are reverted with "agent should try harder". Integrated into the main cycle loop in `cli.py`.
+- `[feat]` **`score_threshold` config option** — New `.nightshift.json` field (default: 3). Controls minimum diff score for cycle acceptance.
+- `[type]` **`DiffScore` TypedDict** — New type in `types.py` for structured diff scoring results.
+
 ## Changed
 
 ## Internal
 
 - `[test]` **+5 merge_config tests** — Covers list extension, deduplication, scalar override, and default immutability
 - `[test]` **+6 run_command tests** — Covers output capture, exit codes, log file writing, timeout kill, partial output on timeout, and normal completion with timeout set
+- `[test]` **+11 diff scorer tests** — 4 unit tests for `_diff_line_score` and `_has_test_files`, 4 integration tests for `score_diff` with real git repos (security fix, trivial fix, test bonus, no cycle result)
+- `[meta]` **S603/S607 suppressed in tests** — Tests use subprocess for git setup; safe in test context
 - `[docs]` **Merge strategy** — Always `--merge` (never `--squash`) + `--admin`. All commits preserved on main.
 - `[docs]` **Release notes convention** — GitHub releases include highlights + full changelog, self-contained.

--- a/docs/vision-tracker/TRACKER.md
+++ b/docs/vision-tracker/TRACKER.md
@@ -9,8 +9,8 @@ This file is the single source of truth for how close Nightshift is to its visio
 ## Overall Progress
 
 ```
-NIGHTSHIFT VISION                              ██████████░░░░░░░░░░  47%
-├── Loop 1 — Hardening Loop                    ███████████████░░░░░  76%
+NIGHTSHIFT VISION                              ██████████░░░░░░░░░░  49%
+├── Loop 1 — Hardening Loop                    ████████████████░░░░  81%
 ├── Loop 2 — Feature Builder Loop              ░░░░░░░░░░░░░░░░░░░░   0%
 ├── Self-Maintaining Repo                      ███████████░░░░░░░░░  54%
 └── Meta-Prompt System                         ████████████░░░░░░░░  57%
@@ -18,7 +18,7 @@ NIGHTSHIFT VISION                              ██████████░
 
 ---
 
-## Loop 1 — Hardening Loop (76%)
+## Loop 1 — Hardening Loop (81%)
 
 The core loop works end-to-end. The orchestrator, agent adapters, verification, and state tracking are functional. What's missing: intelligence improvements that make the agent find better issues.
 
@@ -37,8 +37,8 @@ The core loop works end-to-end. The orchestrator, agent adapters, verification, 
 | Path bias detection | Done | ████████████████████ 100% |
 | Hot-file protection | Done | ████████████████████ 100% |
 | Halt conditions | Done | ████████████████████ 100% |
-| Test suite (123 tests) | Done | ████████████████████ 100% |
-| Post-cycle diff scorer | Not started | ░░░░░░░░░░░░░░░░░░░░ 0% |
+| Test suite (145 tests) | Done | ████████████████████ 100% |
+| Post-cycle diff scorer | Done | ████████████████████ 100% |
 | Cycle-to-cycle state injection | Not started | ░░░░░░░░░░░░░░░░░░░░ 0% |
 | Test writing incentives | Not started | ░░░░░░░░░░░░░░░░░░░░ 0% |
 | Backend exploration forcing | Not started | ░░░░░░░░░░░░░░░░░░░░ 0% |

--- a/nightshift/__init__.py
+++ b/nightshift/__init__.py
@@ -34,6 +34,7 @@ from nightshift.cycle import (
     extract_json,
     parse_cycle_result,
     recent_hot_files,
+    score_diff,
     verify_cycle,
 )
 from nightshift.errors import NightshiftError
@@ -57,6 +58,7 @@ from nightshift.types import (
     CycleEntry,
     CycleResult,
     CycleVerification,
+    DiffScore,
     Fix,
     LoggedIssue,
     NightshiftConfig,
@@ -90,6 +92,7 @@ __all__ = [
     "CycleEntry",
     "CycleResult",
     "CycleVerification",
+    "DiffScore",
     "Fix",
     "LoggedIssue",
     "NightshiftConfig",
@@ -137,6 +140,7 @@ __all__ = [
     "run_command",
     "run_nightshift",
     "run_shell_string",
+    "score_diff",
     "summarize",
     "sync_shift_log",
     "top_path",

--- a/nightshift/cli.py
+++ b/nightshift/cli.py
@@ -19,6 +19,7 @@ from nightshift.cycle import (
     extract_json,
     parse_cycle_result,
     recent_hot_files,
+    score_diff,
     verify_cycle,
 )
 from nightshift.errors import NightshiftError
@@ -214,6 +215,32 @@ def run_nightshift(args: argparse.Namespace, *, test_mode: bool) -> int:
             )
             if state["counters"]["failed_verifications"] >= int(config["stop_after_failed_verifications"]):
                 state["halt_reason"] = "Failed verification threshold reached."
+            write_json(state_path, state)
+            continue
+
+        # Score the diff before accepting.
+        diff_score = score_diff(
+            worktree_dir=worktree_dir,
+            pre_head=pre_head,
+            cycle_result=cycle_result,
+            files_touched=verification["files_touched"],
+        )
+        threshold = int(config["score_threshold"])
+        print_status(f"Diff score: {diff_score['score']}/10 ({diff_score['reason']})")
+        if diff_score["score"] < threshold and verification["files_touched"]:
+            print_status(
+                f"Score {diff_score['score']} is below threshold {threshold}. "
+                "Reverting cycle -- agent should try harder."
+            )
+            revert_cycle(worktree_dir, pre_head)
+            state["cycles"].append(
+                {
+                    "cycle": cycle_number,
+                    "status": "low-score",
+                    "cycle_result": cycle_result,
+                    "verification": verification,
+                }
+            )
             write_json(state_path, state)
             continue
 

--- a/nightshift/config.py
+++ b/nightshift/config.py
@@ -49,6 +49,7 @@ def _build_config(raw: dict[str, Any]) -> NightshiftConfig:
         max_low_impact_fixes_per_shift=_require_int(raw, "max_low_impact_fixes_per_shift"),
         stop_after_failed_verifications=_require_int(raw, "stop_after_failed_verifications"),
         stop_after_empty_cycles=_require_int(raw, "stop_after_empty_cycles"),
+        score_threshold=_require_int(raw, "score_threshold"),
     )
 
 

--- a/nightshift/constants.py
+++ b/nightshift/constants.py
@@ -50,6 +50,7 @@ DEFAULT_CONFIG: NightshiftConfig = {
     "max_low_impact_fixes_per_shift": 4,
     "stop_after_failed_verifications": 2,
     "stop_after_empty_cycles": 2,
+    "score_threshold": 3,
 }
 
 SAFE_ARTIFACT_DIRS = [

--- a/nightshift/cycle.py
+++ b/nightshift/cycle.py
@@ -16,6 +16,7 @@ from nightshift.state import top_path
 from nightshift.types import (
     CycleResult,
     CycleVerification,
+    DiffScore,
     NightshiftConfig,
     ShiftState,
 )
@@ -364,3 +365,121 @@ def verify_cycle(
             violations.append(f"Verification command failed: `{verify_command}`")
 
     return (not violations), verification
+
+
+# --- Diff Scorer -------------------------------------------------------------
+
+# Keywords in diff lines that signal high-impact changes, mapped to base scores.
+_SECURITY_PATTERNS: list[tuple[re.Pattern[str], int]] = [
+    (re.compile(r"(sql.?inject|xss|csrf|auth|sanitiz|escap|vulnerab)", re.IGNORECASE), 8),
+    (re.compile(r"(password|secret|token|credential|api.?key)", re.IGNORECASE), 7),
+]
+
+_ERROR_HANDLING_PATTERNS: list[tuple[re.Pattern[str], int]] = [
+    (re.compile(r"(try|catch|except|raise|throw|Error|Exception)", re.IGNORECASE), 5),
+    (re.compile(r"(error.?handl|fallback|retry|timeout)", re.IGNORECASE), 5),
+]
+
+# Category name -> base score for that category of fix (from CATEGORY_ORDER priority).
+_CATEGORY_SCORES: dict[str, int] = {
+    "Security": 8,
+    "Error Handling": 6,
+    "Tests": 6,
+    "A11y": 5,
+    "Code Quality": 3,
+    "Performance": 5,
+    "Polish": 2,
+}
+
+
+def _diff_line_score(diff_text: str) -> int:
+    """Scan diff added-lines for high-impact patterns. Return the max signal found."""
+    best = 0
+    for line in diff_text.splitlines():
+        if not line.startswith("+"):
+            continue
+        for pattern, score in _SECURITY_PATTERNS:
+            if pattern.search(line):
+                best = max(best, score)
+        for pattern, score in _ERROR_HANDLING_PATTERNS:
+            if pattern.search(line):
+                best = max(best, score)
+    return best
+
+
+def _has_test_files(files: list[str]) -> bool:
+    """Return True if any touched file looks like a test file."""
+    for f in files:
+        name = f.rsplit("/", 1)[-1].lower()
+        if name.startswith("test_") or name.endswith("_test.py") or name.endswith(".test.ts"):
+            return True
+        if name.endswith(".test.js") or name.endswith(".test.tsx") or name.endswith(".test.jsx"):
+            return True
+        if name.endswith(".spec.ts") or name.endswith(".spec.js"):
+            return True
+    return False
+
+
+def score_diff(
+    *,
+    worktree_dir: Path,
+    pre_head: str,
+    cycle_result: CycleResult | None,
+    files_touched: list[str],
+) -> DiffScore:
+    """Score a cycle's changes on a 1-10 scale based on production impact.
+
+    Scoring factors:
+    1. Category of fixes (from cycle_result) - higher-priority categories score higher
+    2. Diff content analysis - security/error patterns in added lines boost the score
+    3. Test bonus - writing tests adds +1
+    4. Category breadth bonus - multiple categories in one cycle adds +1
+    """
+    base = 1  # minimum score for any accepted cycle
+
+    # Factor 1: category scores from structured result
+    categories_seen: set[str] = set()
+    if cycle_result is not None:
+        for fix in cycle_result.get("fixes", []):
+            cat = fix.get("category", "")
+            if cat:
+                categories_seen.add(cat)
+                cat_score = _CATEGORY_SCORES.get(cat, 3)
+                base = max(base, cat_score)
+
+    # Factor 2: diff content analysis
+    try:
+        diff_text = git(worktree_dir, "diff", f"{pre_head}..HEAD")
+    except NightshiftError:
+        diff_text = ""
+    line_score = _diff_line_score(diff_text)
+    base = max(base, line_score)
+
+    # Factor 3: test bonus
+    test_bonus = _has_test_files(files_touched)
+    if test_bonus:
+        base = min(base + 1, 10)
+
+    # Factor 4: category breadth bonus
+    category_bonus = len(categories_seen) >= 2
+    if category_bonus:
+        base = min(base + 1, 10)
+
+    # Build reason string
+    parts: list[str] = []
+    if categories_seen:
+        parts.append(f"categories: {', '.join(sorted(categories_seen))}")
+    if line_score > 0:
+        parts.append(f"diff signal: {line_score}")
+    if test_bonus:
+        parts.append("test file included")
+    if category_bonus:
+        parts.append("multi-category breadth")
+    reason = "; ".join(parts) if parts else "no high-impact signals detected"
+
+    return DiffScore(
+        score=min(base, 10),
+        reason=reason,
+        category_bonus=category_bonus,
+        test_bonus=test_bonus,
+    )

--- a/nightshift/types.py
+++ b/nightshift/types.py
@@ -20,6 +20,16 @@ class NightshiftConfig(TypedDict):
     max_low_impact_fixes_per_shift: int
     stop_after_failed_verifications: int
     stop_after_empty_cycles: int
+    score_threshold: int
+
+
+class DiffScore(TypedDict):
+    """Result from scoring a cycle's diff for production impact."""
+
+    score: int
+    reason: str
+    category_bonus: bool
+    test_bonus: bool
 
 
 class Counters(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101", "S108", "C408"]
+"tests/*" = ["S101", "S108", "C408", "S603", "S607"]
 "nightshift/constants.py" = ["T201"]
 "nightshift/cli.py" = ["T201"]
 "nightshift/shell.py" = ["S603", "S607"]  # subprocess with variable args -- this is the orchestrator's job

--- a/tests/test_nightshift.py
+++ b/tests/test_nightshift.py
@@ -52,6 +52,7 @@ class TestConstants:
             "max_low_impact_fixes_per_shift",
             "stop_after_failed_verifications",
             "stop_after_empty_cycles",
+            "score_threshold",
         }
         assert set(nightshift.DEFAULT_CONFIG.keys()) == expected
 
@@ -1011,6 +1012,149 @@ class TestCleanupSafeArtifacts:
         normal.touch()
         nightshift.cleanup_safe_artifacts(tmp_path)
         assert normal.exists()
+
+
+# --- Diff Scorer -------------------------------------------------------------
+
+
+class TestDiffLineScore:
+    def test_security_pattern_scores_high(self) -> None:
+        from nightshift.cycle import _diff_line_score
+
+        diff = "+    sanitize_input(user_data)\n"
+        assert _diff_line_score(diff) >= 7
+
+    def test_error_handling_pattern(self) -> None:
+        from nightshift.cycle import _diff_line_score
+
+        diff = "+    try:\n+        do_thing()\n+    except ValueError:\n"
+        assert _diff_line_score(diff) >= 5
+
+    def test_no_patterns_scores_zero(self) -> None:
+        from nightshift.cycle import _diff_line_score
+
+        diff = "+    x = 1\n+    y = 2\n"
+        assert _diff_line_score(diff) == 0
+
+    def test_only_added_lines_scanned(self) -> None:
+        from nightshift.cycle import _diff_line_score
+
+        diff = "-    sanitize_input(user_data)\n x = 1\n"
+        assert _diff_line_score(diff) == 0
+
+
+class TestHasTestFiles:
+    def test_python_test_file(self) -> None:
+        from nightshift.cycle import _has_test_files
+
+        assert _has_test_files(["src/main.py", "tests/test_main.py"])
+
+    def test_js_spec_file(self) -> None:
+        from nightshift.cycle import _has_test_files
+
+        assert _has_test_files(["src/app.ts", "src/app.spec.ts"])
+
+    def test_no_test_files(self) -> None:
+        from nightshift.cycle import _has_test_files
+
+        assert not _has_test_files(["src/main.py", "src/utils.py"])
+
+
+class TestScoreDiff:
+    def test_security_fix_scores_high(self, tmp_path: Path) -> None:
+        # Set up a git repo with a security-related commit
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, capture_output=True, check=True)
+        (tmp_path / "dummy.txt").write_text("initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True, check=True)
+        pre_head = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        (tmp_path / "auth.py").write_text("sanitize_input(user_data)\n")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "fix auth"], cwd=tmp_path, capture_output=True, check=True)
+
+        result = nightshift.score_diff(
+            worktree_dir=tmp_path,
+            pre_head=pre_head,
+            cycle_result=nightshift.CycleResult(
+                status="done",
+                fixes=[{"title": "fix auth", "category": "Security", "impact": "high", "files": ["auth.py"]}],
+                logged_issues=[],
+            ),
+            files_touched=["auth.py"],
+        )
+        assert result["score"] >= 8
+
+    def test_trivial_fix_scores_low(self, tmp_path: Path) -> None:
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, capture_output=True, check=True)
+        (tmp_path / "dummy.txt").write_text("initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True, check=True)
+        pre_head = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        (tmp_path / "style.css").write_text("body { color: red; }\n")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "polish"], cwd=tmp_path, capture_output=True, check=True)
+
+        result = nightshift.score_diff(
+            worktree_dir=tmp_path,
+            pre_head=pre_head,
+            cycle_result=nightshift.CycleResult(
+                status="done",
+                fixes=[{"title": "color fix", "category": "Polish", "impact": "low", "files": ["style.css"]}],
+                logged_issues=[],
+            ),
+            files_touched=["style.css"],
+        )
+        assert result["score"] <= 3
+
+    def test_test_bonus_applied(self, tmp_path: Path) -> None:
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, capture_output=True, check=True)
+        (tmp_path / "dummy.txt").write_text("initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True, check=True)
+        pre_head = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        (tmp_path / "test_auth.py").write_text("def test_login(): pass\n")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "add test"], cwd=tmp_path, capture_output=True, check=True)
+
+        result = nightshift.score_diff(
+            worktree_dir=tmp_path,
+            pre_head=pre_head,
+            cycle_result=None,
+            files_touched=["test_auth.py"],
+        )
+        assert result["test_bonus"] is True
+
+    def test_no_cycle_result_still_works(self, tmp_path: Path) -> None:
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, capture_output=True, check=True)
+        (tmp_path / "dummy.txt").write_text("initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True, check=True)
+        pre_head = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+        result = nightshift.score_diff(
+            worktree_dir=tmp_path,
+            pre_head=pre_head,
+            cycle_result=None,
+            files_touched=[],
+        )
+        assert isinstance(result["score"], int)
+        assert 1 <= result["score"] <= 10
 
 
 # --- Discover Base Branch ----------------------------------------------------


### PR DESCRIPTION
## Summary
- `score_diff()` scores cycle changes 1-10 based on production impact
- Cycles below `score_threshold` (default 3) are reverted
- Factors: category priority, diff content patterns, test bonus, breadth bonus
- New config option: `score_threshold`
- New type: `DiffScore`

## Test plan
- [x] 11 new tests (4 unit + 4 integration with real git repos + 3 helper tests)
- [x] All 145 tests pass
- [x] mypy strict, ruff lint+format clean
- [x] Dry-run works for both adapters