### PR TITLE
docs: review notes must become tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Full daemon operations guide with troubleshooting: `docs/ops/DAEMON.md`
 
 - **Never push to main directly.** Branch, PR, sub-agent review, merge.
 - Branch naming: `feat/`, `fix/`, `docs/`, `refactor/`, `release/`
+- **Review notes MUST become tasks.** If the code review sub-agent flags advisory notes, known limitations, or follow-up items but still passes, you MUST create follow-up tasks in `docs/tasks/` before merging. "Known limitation" is not a valid reason to skip — the task queue tracks deferred work.
 - Full workflow: `docs/ops/OPERATIONS.md` under "Git Workflow"
 
 ## Environment

--- a/docs/learnings/2026-04-04-review-notes-must-become-tasks.md
+++ b/docs/learnings/2026-04-04-review-notes-must-become-tasks.md
@@ -1,0 +1,24 @@
+# Learning: Code review advisory notes must become follow-up tasks
+
+**Date**: 2026-04-04
+**Session**: Human-monitored daemon run (sessions 1-3)
+**Type**: process failure
+
+## What happened
+
+The code review sub-agent on PRs #30 and #31 flagged advisory notes (context flooding vector, new file creation not detected, symlink attack on instruction files). The building agent said "known limitations, not blocking" and merged without creating follow-up tasks. The human monitor caught this and had to create the tasks manually.
+
+## The lesson
+
+Code review notes that say "not blocking" or "advisory" still represent real gaps. If the review flags something, one of two things must happen:
+
+1. Fix it before merging (if it's small enough)
+2. Create a follow-up task with the exact issue and acceptance criteria
+
+"Known limitation" is not a valid disposition. The whole point of the task queue is to track work that can't be done right now. Dismissing a review note without a task means it disappears from the system's memory.
+
+## Evidence
+
+- PR #30 review: flagged context flooding and symlink vectors, no tasks created
+- PR #31 review: flagged snapshot bypass and new file creation, no tasks created
+- Human created tasks #0036 and #0037 retroactively

--- a/docs/ops/OPERATIONS.md
+++ b/docs/ops/OPERATIONS.md
@@ -478,6 +478,8 @@ Report: PASS (merge it) or FAIL (list what needs fixing).
 ```
 If the review says FAIL, fix the issues, push again, re-review. Only merge on PASS.
 
+**Review notes MUST become tasks.** If the review passes but flags advisory notes, known limitations, or follow-up suggestions, you MUST either fix them before merging OR create follow-up tasks in `docs/tasks/` with the exact issue and acceptance criteria. "Known limitation" is not a valid disposition — the task queue exists to track deferred work. Dismissing a review note without a task means it disappears from the system's memory.
+
 ### Merge strategy
 - **Always use regular merge** (`--merge`), never `--squash`. Every commit on the branch must be preserved on main. If you made 10 commits, all 10 appear in main's history.
 - **Always use `--admin` flag** when merging PRs. The agent is the sole creator, maintainer, and admin of this repo. No human review approval is required. The sub-agent code review replaces human review.

--- a/docs/ops/PRE-PUSH-CHECKLIST.md
+++ b/docs/ops/PRE-PUSH-CHECKLIST.md
@@ -49,6 +49,12 @@ Your answers determine which sections below are mandatory.
 - [ ] If task was too big and you only did part of it: mark done, create follow-up task(s)
 - [ ] Handoff references the next pending task numbers
 
+## Part 2c: Code Review Notes (AFTER sub-agent review)
+
+- [ ] If the review flagged advisory notes, known limitations, or follow-up suggestions: each one has EITHER been fixed before merging OR has a new task in `docs/tasks/` with acceptance criteria
+- [ ] "Known limitation" or "not blocking" is NOT a valid reason to skip creating a task — the task queue tracks deferred work
+- [ ] Handoff "Known Issues" or "Next Session Should" references any new follow-up tasks created from review notes
+
 ---
 
 ## Part 3: Handoff (ALWAYS)

--- a/docs/prompt/evolve-auto.md
+++ b/docs/prompt/evolve-auto.md
@@ -24,6 +24,12 @@ works in production. This means:
 If after 3 attempts something still doesn't work, log it as a known issue
 in the handoff and move on to the next priority. Do not push broken code.
 
+REVIEW NOTES RULE: When the code review sub-agent PASSes but flags advisory
+notes, known limitations, or follow-up suggestions — you MUST create a
+follow-up task in docs/tasks/ for EACH note with clear acceptance criteria.
+"Known limitation" is NOT a valid reason to skip creating a task. The task
+queue is the system's memory. Anything not tracked as a task is forgotten.
+
 All other steps remain the same. Follow the evolve prompt exactly.
 
 DAEMON CONTEXT: You are running inside `scripts/daemon.sh` via tmux.

--- a/docs/prompt/evolve.md
+++ b/docs/prompt/evolve.md
@@ -344,6 +344,13 @@ EOF
 #    then reads the diff with `gh pr diff <number>`.
 #    Reports PASS or FAIL with specific file:line references.
 
+# 5b. REVIEW NOTES MUST BECOME TASKS
+#     If the review PASSes but flags advisory notes, known limitations,
+#     or follow-up suggestions: you MUST create a follow-up task in
+#     docs/tasks/ for EACH note, with clear acceptance criteria.
+#     "Known limitation" is NOT a valid reason to skip creating a task.
+#     The task queue is the system's memory -- anything not tracked is forgotten.
+
 # 6. If PASS: merge (always --merge to preserve all commits, --admin since you are sole maintainer)
 gh pr merge --merge --delete-branch --admin
 

--- a/docs/tasks/0036.md
+++ b/docs/tasks/0036.md
@@ -1,0 +1,21 @@
+---
+
+## status: pending
+priority: normal
+target: v0.0.7
+created: 2026-04-04
+completed:
+
+# Prompt guard: add size cap on instruction file content
+
+The prompt injection protection (task #0024) pre-loads target repo instruction files (CLAUDE.md, AGENTS.md, etc.) into the cycle prompt. There is no size cap on the content. A malicious repo could use extremely large instruction files to flood the agent's context window, crowding out the actual cycle directives.
+
+Flagged by code review sub-agent on PR #30 as an advisory note.
+
+## Acceptance Criteria
+
+- Add a MAX_INSTRUCTION_FILE_SIZE constant (e.g., 10KB per file, 30KB total)
+- `read_repo_instructions()` truncates files that exceed the limit
+- Truncation is logged with a warning in the prompt (so the agent knows content was cut)
+- Tests cover truncation behavior
+

--- a/docs/tasks/0037.md
+++ b/docs/tasks/0037.md
@@ -1,0 +1,23 @@
+---
+status: pending
+priority: normal
+target: v0.0.7
+created: 2026-04-04
+completed:
+---
+
+# Prompt guard: detect new file creation and symlink attacks
+
+Two gaps in the self-modification guard (task #0025):
+
+1. **New file creation**: The guard only checks files listed in PROMPT_GUARD_FILES. If the agent creates a new prompt-like file (e.g., a new .md in docs/prompt/) that isn't in the list, the guard won't detect it.
+
+2. **Symlink attacks on instruction files**: `read_repo_instructions()` (task #0024) does not check whether instruction files are symlinks. A malicious repo could symlink CLAUDE.md to /etc/passwd or another sensitive file.
+
+Both flagged by code review sub-agent on PRs #30 and #31 as advisory notes.
+
+## Acceptance Criteria
+- [ ] Prompt guard detects new files in docs/prompt/ and nightshift/SKILL.md's directory
+- [ ] `read_repo_instructions()` rejects symlinks with a warning
+- [ ] Tampered flag set if new prompt files are detected post-session
+- [ ] Tests cover both scenarios

--- a/docs/tasks/GUIDE.md
+++ b/docs/tasks/GUIDE.md
@@ -53,9 +53,12 @@ What to build and why.
 
 ## When the agent finishes a task
 
-The agent does TWO things:
+The agent does THREE things:
 1. Marks the current task `done` with `completed` date
 2. Creates the NEXT task(s) based on what it learned — the vision tracker, the roadmap, or what it discovered while building
+3. Creates follow-up tasks for ANY code review advisory notes, known limitations, or suggestions that weren't fixed before merging
+
+**Rule: review notes must become tasks.** If the code review sub-agent passes but flags issues as "advisory", "known limitation", or "not blocking", each note MUST get a follow-up task with clear acceptance criteria. The task queue is the system's memory — anything not tracked as a task will be forgotten.
 
 This is how the queue stays alive. The agent always leaves work for the next session.
 


### PR DESCRIPTION
## Summary
- Code review sub-agent was flagging advisory notes but the building agent dismissed them without creating follow-up tasks — the issues vanished from system memory
- Adds the "review notes must become tasks" rule to every doc the agent reads: CLAUDE.md, OPERATIONS.md, PRE-PUSH-CHECKLIST.md, evolve.md, evolve-auto.md, task GUIDE.md
- Creates tasks #0036 (instruction file size cap) and #0037 (new file creation + symlink detection) retroactively from PR #30/#31 review notes
- Adds a learning documenting the failure pattern

## Test plan
- Docs only, no code changes
- Verify the rule appears in all 6 docs the daemon agent reads