### PR TITLE
docs: always use make check + never push directly to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Full daemon operations guide with troubleshooting: `docs/ops/DAEMON.md`
 - **Never push to main directly.** Branch, PR, sub-agent review, merge.
 - Branch naming: `feat/`, `fix/`, `docs/`, `refactor/`, `release/`
 - **Review notes MUST become tasks.** If the code review sub-agent flags advisory notes, known limitations, or follow-up items but still passes, you MUST create follow-up tasks in `docs/tasks/` before merging. "Known limitation" is not a valid reason to skip — the task queue tracks deferred work.
+- **If CI fails after merge:** create a `fix/` branch and PR. Never push directly to main, even for "trivial" fixes.
 - Full workflow: `docs/ops/OPERATIONS.md` under "Git Workflow"
 
 ## Environment
@@ -86,6 +87,8 @@ Full daemon operations guide with troubleshooting: `docs/ops/DAEMON.md`
 - Test target: `https://github.com/fazxes/Phractal`
 
 ## Code Quality Rules
+
+**Always use `make check` for verification.** Never run ruff, mypy, or pytest individually as your final check — `make check` runs all of them against both `nightshift/` and `tests/`. Partial checks miss things.
 
 These are enforced by CI. Non-negotiable.
 

--- a/docs/learnings/2026-04-04-always-make-check-never-partial-lint.md
+++ b/docs/learnings/2026-04-04-always-make-check-never-partial-lint.md
@@ -1,0 +1,21 @@
+# Learning: Always use `make check`, never partial lint commands
+
+**Date**: 2026-04-04
+**Session**: Human-monitored daemon run (session 6, PR #35)
+**Type**: failure
+
+## What happened
+
+The agent ran `ruff check nightshift/` as its final verification but not `ruff check nightshift/ tests/`. Two RUF005 lint errors in `tests/test_nightshift.py` were missed. The PR was merged, CI failed on main, and the agent pushed two direct-to-main fixes (also violating the branch+PR rule) before CI went green.
+
+## The lesson
+
+1. **Always use `make check`** as the final verification. It runs ruff, mypy, and pytest across both `nightshift/` and `tests/`. Running individual commands against individual directories is how errors slip through.
+
+2. **If CI fails after merge, fix via `fix/` branch + PR.** Never push directly to main. The agent rationalized "trivial lint fix" as an excuse to skip the workflow. There is no exception — every change to main goes through a PR.
+
+## Evidence
+
+- PR #35 merged with lint failure (RUF005 in tests/test_nightshift.py:6279,6287)
+- Two direct pushes to main to fix: commits 932d16d and d98252d
+- GitHub warned: "Bypassed rule violations: Changes must be made through a pull request"

--- a/docs/prompt/evolve-auto.md
+++ b/docs/prompt/evolve-auto.md
@@ -9,6 +9,12 @@ If you are genuinely unsure between two options (both seem equally impactful),
 pick the one that is smaller in scope — ship something small rather than
 getting stuck deciding.
 
+VERIFICATION RULE: Always use `make check` as your final verification.
+NEVER run ruff, mypy, or pytest individually as your final check —
+`make check` covers both nightshift/ AND tests/. Partial checks miss things.
+Running `ruff check nightshift/` without `tests/` is how lint errors
+reach main. Run `make check`. Every time. No exceptions.
+
 PRODUCTION-READINESS RULE: Do NOT push anything you are not 100% certain
 works in production. This means:
 - Every code change has tests. No exceptions.
@@ -23,6 +29,10 @@ works in production. This means:
 
 If after 3 attempts something still doesn't work, log it as a known issue
 in the handoff and move on to the next priority. Do not push broken code.
+
+CI FAILURE RULE: If CI fails AFTER you merge a PR, create a `fix/` branch
+and PR for the fix. NEVER push directly to main, not even for "trivial"
+lint fixes. The branch-PR-merge workflow exists for a reason.
 
 REVIEW NOTES RULE: When the code review sub-agent PASSes but flags advisory
 notes, known limitations, or follow-up suggestions — you MUST create a

--- a/docs/prompt/evolve.md
+++ b/docs/prompt/evolve.md
@@ -368,11 +368,14 @@ After merging, verify main is healthy:
 # Wait for CI on main (check latest run)
 gh run list --branch main --limit 1
 # If status is "completed" + "success": proceed
-# If status is "failure": immediately revert
-bash scripts/rollback.sh <merge-commit>
+# If status is "failure": fix via branch+PR or revert. NEVER push directly to main.
+git checkout -b fix/ci-failure
+# ... fix the issue ...
+gh pr create --title "fix: ..." --body "..."
+gh pr merge --merge --delete-branch --admin
 ```
 
-Do NOT proceed to the next step if CI on main is failing. Fix it first or revert.
+Do NOT proceed to the next step if CI on main is failing. Fix it first or revert. **Always fix via a branch and PR — never push directly to main, even for trivial fixes.**
 
 ## STEP 10 — HANDOFF WITH EVALUATION FLAG
 


### PR DESCRIPTION
## Summary
- Agent ran `ruff check nightshift/` (missing `tests/`) — lint errors reached main via PR #35
- Then pushed two fixes directly to main instead of using branch+PR
- Adds two rules to every doc the agent reads:
  1. Always use `make check` for final verification, never partial lint/type/test commands
  2. If CI fails after merge, fix via `fix/` branch + PR — never push directly to main

## Files
- `CLAUDE.md` — code quality + git workflow rules
- `docs/prompt/evolve-auto.md` — VERIFICATION RULE + CI FAILURE RULE
- `docs/prompt/evolve.md` — Step 9 updated with branch+PR flow
- `docs/learnings/` — new learning documenting the failure

## Test plan
- Docs only, no code changes