### PR TITLE
fix: restore task #0040 and renumber review follow-up to #0042

### DIFF
--- a/docs/tasks/0040.md
+++ b/docs/tasks/0040.md
@@ -1,18 +1,59 @@
 ---
 status: pending
-priority: low
-target: v0.0.8
+priority: normal
+target: v0.0.7
 created: 2026-04-04
 completed:
 ---
 
-# Add test to assert AGENT_DEFAULT_MODELS matches DEFAULT_CONFIG
+# Create CONTRIBUTING.md — agent-to-agent collaboration protocol
 
-`AGENT_DEFAULT_MODELS["codex"]` and `DEFAULT_CONFIG["codex_model"]` are currently in sync but decoupled. If someone updates one without the other, Codex sessions silently use stale pricing.
+This repo is built by autonomous agents (the Nightshift daemons). When an external contributor opens a PR, their agent is contributing to a repo where another agent is the maintainer. This guide must make that work seamlessly — agent to agent.
 
-Flagged by code review on PR #41.
+## Who This Is For
+
+Two audiences, both agents:
+
+1. **The resident agent** (Nightshift daemon) — needs to understand that an external contribution is happening, not get confused by unfamiliar branches/PRs, and know how to review and integrate external work without breaking its own workflow.
+
+2. **The contributing agent** (someone else's Claude/Codex/etc.) — needs to understand the repo's conventions, quality gates, and workflow well enough to produce a PR that the resident agent can process without human intervention.
+
+The human's role is oversight: they review, approve, merge. But the agents on both sides need to be able to do the actual work.
+
+## Design Principle
+
+This guide should be written BY an agent, FOR agents. The Nightshift daemon building this should:
+
+- Analyze how it actually works (read its own prompts, handoffs, learnings, task system)
+- Design the guide so a foreign agent landing in this repo can produce clean, mergeable PRs on the first try
+- Design it so the resident daemon doesn't choke on external PRs (unexpected branches, unfamiliar task IDs, missing handoff context)
+- Structure everything for LLM context windows — not human narrative
+
+The agent building this decides the structure. Don't copy-paste from CLAUDE.md — synthesize what an outside agent actually needs to know vs what the resident agent already has in its context.
+
+## Key Questions the Agent Should Answer
+
+- What does a contributing agent need to know to not break the resident agent's workflow?
+- How should external PRs be structured so the review daemon can process them?
+- What conventions are non-negotiable (naming, quality gates, typing, ASCII-only)?
+- How does a contributing agent signal intent without access to the task queue?
+- What happens when the resident daemon encounters an unexpected PR — how should CONTRIBUTING.md prevent confusion?
+- How should the contributing agent's commit messages, branch names, and PR descriptions be formatted for machine parsing?
+
+## Constraints
+
+- Must follow existing code quality rules (ASCII-only in source, etc.)
+- Must not duplicate what's already in CLAUDE.md — reference it, don't repeat it
+- Structured for LLM consumption (clear headers, short sections, no prose walls)
+- The human will review before merge — so make it reviewable
 
 ## Acceptance Criteria
-- [ ] Test asserts `AGENT_DEFAULT_MODELS["codex"] == DEFAULT_CONFIG["codex_model"]`
-- [ ] Test asserts `AGENT_DEFAULT_MODELS["claude"] == DEFAULT_CONFIG["claude_model"]`
-- [ ] Both tests in TestCostConstants class
+
+- `CONTRIBUTING.md` exists at repo root
+- Written from the perspective of the working agent, not a human maintainer
+- Covers both sides: what contributing agents need AND how the resident agent handles external PRs
+- Specifies machine-parseable PR/commit conventions for agent-to-agent handoff
+- Documents non-negotiable quality gates that external agents must pass
+- Structured for fast LLM parsing
+- Does not duplicate CLAUDE.md content
+- Reviewed and merged via standard PR workflow

--- a/docs/tasks/0042.md
+++ b/docs/tasks/0042.md
@@ -1,0 +1,18 @@
+---
+status: pending
+priority: low
+target: v0.0.8
+created: 2026-04-04
+completed:
+---
+
+# Add test to assert AGENT_DEFAULT_MODELS matches DEFAULT_CONFIG
+
+`AGENT_DEFAULT_MODELS["codex"]` and `DEFAULT_CONFIG["codex_model"]` are currently in sync but decoupled. If someone updates one without the other, Codex sessions silently use stale pricing.
+
+Flagged by code review on PR #41.
+
+## Acceptance Criteria
+- [ ] Test asserts `AGENT_DEFAULT_MODELS["codex"] == DEFAULT_CONFIG["codex_model"]`
+- [ ] Test asserts `AGENT_DEFAULT_MODELS["claude"] == DEFAULT_CONFIG["claude_model"]`
+- [ ] Both tests in TestCostConstants class


### PR DESCRIPTION
## Summary
- PR #44 accidentally overwrote task #0040 (CONTRIBUTING.md agent-to-agent protocol) with a different task
- Restored original #0040 content from commit 02ca7c7
- Moved the AGENT_DEFAULT_MODELS sync test task to #0042

## Test plan
- Docs-only change, no code modifications
- Verified 0040.md content matches original