### PR TITLE
fix: daemon hot-reload — never require manual restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ tmux send-keys -t nightshift C-c            # graceful (after current session)
 tmux kill-session -t nightshift             # immediate
 ```
 
+**Hot reload:** The daemon re-sources `lib-agent.sh` and checks for `daemon.sh` changes at the start of every loop iteration. If the agent modifies shell scripts during a session, the changes take effect next iteration automatically. No manual restart needed.
+
 **WARNING: The daemon and the monitor/human share the same working directory.** Do not run `git checkout`, `git stash`, or any branch-switching commands while the daemon is mid-session — it will corrupt or lose the daemon's uncommitted work.
 
 **Making changes while the daemon is running:** Use a git worktree in `/tmp` instead of touching the main repo:

--- a/docs/learnings/2026-04-05-daemon-hot-reload.md
+++ b/docs/learnings/2026-04-05-daemon-hot-reload.md
@@ -1,0 +1,20 @@
+# Learning: Daemon scripts must hot-reload to maintain autonomy
+
+**Date**: 2026-04-05
+**Session**: Human-monitored daemon run
+**Type**: failure
+
+## What happened
+
+The daemon loaded daemon.sh and lib-agent.sh once at startup. When the builder agent added new features (sync_github_tasks, healer, archive_done_tasks) during a session, they were merged to main but the running daemon process still had the old code. Required manual daemon restart every time a shell script changed — breaking autonomy.
+
+## The fix
+
+1. Re-source lib-agent.sh at the start of every loop iteration (after git reset pulls new code). New functions are available immediately.
+2. Self-restart via exec when daemon.sh itself changes. Compares md5 hash before/after git reset. If different, exec replaces the process with the new version.
+
+## Evidence
+
+- sync_github_tasks built in PR #60, never ran until daemon restarted
+- Healer fix in PR #54 required manual restart
+- Three separate manual restarts needed in one monitoring session

--- a/docs/learnings/INDEX.md
+++ b/docs/learnings/INDEX.md
@@ -14,6 +14,7 @@ Read this file FIRST. Only open individual learning files when they are relevant
 ## Process
 
 - [CONTRIBUTING.md: synthesize, not copy](2026-04-05-contributing-md-synthesis-not-copy.md) — Write external view only; reference CLAUDE.md for details, mirror review-agent gates as checklist
+- [Daemon hot-reload for autonomy](2026-04-05-daemon-hot-reload.md) — Re-source lib-agent.sh every loop; exec self-restart when daemon.sh changes. Never require manual restart.
 - [Review notes must become tasks](2026-04-04-review-notes-must-become-tasks.md) — Code review advisory notes must get follow-up tasks, never dismissed as "known limitation"
 - [Always use make check](2026-04-04-always-make-check-never-partial-lint.md) — Never run ruff/mypy individually; `make check` covers nightshift/ AND tests/
 - [Task selection is mesa-optimization](2026-04-04-task-selection-mesa-optimization.md) — Agent optimizes session success over project progress; queue order is authoritative, handoff is advisory

--- a/docs/ops/DAEMON.md
+++ b/docs/ops/DAEMON.md
@@ -309,6 +309,9 @@ daemon.sh loop iteration
 git fetch + reset --hard origin/main    # clean slate
     |
     v
+source lib-agent.sh + check daemon hash # hot reload (no manual restart needed)
+    |
+    v
 housekeeping                            # rotate logs, prune branches,
   cleanup_old_logs                      #   compact handoffs, archive tasks,
   cleanup_orphan_branches               #   sync GitHub Issues -> task files

--- a/scripts/daemon-overseer.sh
+++ b/scripts/daemon-overseer.sh
@@ -117,6 +117,17 @@ while true; do
     git reset --hard origin/main --quiet 2>/dev/null || true
     git clean -fd --quiet 2>/dev/null || true
 
+    # --- Hot reload: re-source lib-agent.sh to pick up new functions ---
+    source "$SCRIPT_DIR/lib-agent.sh"
+
+    # --- Self-restart: if daemon-overseer.sh changed, exec into new version ---
+    NEW_HASH=$(md5 -q "$SCRIPT_DIR/daemon-overseer.sh" 2>/dev/null || md5sum "$SCRIPT_DIR/daemon-overseer.sh" 2>/dev/null | cut -d' ' -f1)
+    if [ -n "$_DAEMON_HASH" ] && [ "$NEW_HASH" != "$_DAEMON_HASH" ]; then
+        echo "  daemon-overseer.sh changed on main — restarting with new code..."
+        exec bash "$SCRIPT_DIR/daemon-overseer.sh" "$AGENT" "$PAUSE" "$MAX_SESSIONS"
+    fi
+    export _DAEMON_HASH="$NEW_HASH"
+
     # --- Housekeeping: rotate old logs, prune stale branches, compact handoffs, sync issues ---
     cleanup_old_logs "$LOG_DIR" "$KEEP_LOGS"
     cleanup_orphan_branches

--- a/scripts/daemon-review.sh
+++ b/scripts/daemon-review.sh
@@ -117,6 +117,17 @@ while true; do
     git reset --hard origin/main --quiet 2>/dev/null || true
     git clean -fd --quiet 2>/dev/null || true
 
+    # --- Hot reload: re-source lib-agent.sh to pick up new functions ---
+    source "$SCRIPT_DIR/lib-agent.sh"
+
+    # --- Self-restart: if daemon-review.sh changed, exec into new version ---
+    NEW_HASH=$(md5 -q "$SCRIPT_DIR/daemon-review.sh" 2>/dev/null || md5sum "$SCRIPT_DIR/daemon-review.sh" 2>/dev/null | cut -d' ' -f1)
+    if [ -n "$_DAEMON_HASH" ] && [ "$NEW_HASH" != "$_DAEMON_HASH" ]; then
+        echo "  daemon-review.sh changed on main — restarting with new code..."
+        exec bash "$SCRIPT_DIR/daemon-review.sh" "$AGENT" "$PAUSE" "$MAX_SESSIONS"
+    fi
+    export _DAEMON_HASH="$NEW_HASH"
+
     # --- Housekeeping: rotate old logs, prune stale branches, compact handoffs, sync issues ---
     cleanup_old_logs "$LOG_DIR" "$KEEP_LOGS"
     cleanup_orphan_branches

--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -119,6 +119,17 @@ while true; do
     git reset --hard origin/main --quiet 2>/dev/null || true
     git clean -fd --quiet 2>/dev/null || true
 
+    # --- Hot reload: re-source lib-agent.sh to pick up new functions ---
+    source "$SCRIPT_DIR/lib-agent.sh"
+
+    # --- Self-restart: if daemon.sh changed, exec into new version ---
+    NEW_HASH=$(md5 -q "$SCRIPT_DIR/daemon.sh" 2>/dev/null || md5sum "$SCRIPT_DIR/daemon.sh" 2>/dev/null | cut -d' ' -f1)
+    if [ -n "$_DAEMON_HASH" ] && [ "$NEW_HASH" != "$_DAEMON_HASH" ]; then
+        echo "  daemon.sh changed on main — restarting with new code..."
+        exec bash "$SCRIPT_DIR/daemon.sh" "$AGENT" "$PAUSE" "$MAX_SESSIONS"
+    fi
+    export _DAEMON_HASH="$NEW_HASH"
+
     # --- Housekeeping: rotate old logs, prune stale branches, compact handoffs, archive tasks, sync issues ---
     cleanup_old_logs "$LOG_DIR" "$KEEP_LOGS"
     cleanup_orphan_branches


### PR DESCRIPTION
## Summary
- All 3 looping daemons re-source lib-agent.sh every iteration
- Self-restart via exec when daemon.sh changes (md5 hash comparison)
- Updated CLAUDE.md, DAEMON.md, learnings INDEX

## Test plan
- bash -n validates all 3 scripts
- First iteration: _DAEMON_HASH is empty, no restart (safe)
- Subsequent iterations: hash matches, no restart (fast)
- When daemon.sh changes on main: hash mismatch, exec replaces process