### PR TITLE
release: v0.0.6 and v0.0.7

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -47,5 +47,6 @@ Beta period (`0.x.x`): breaking changes can happen in any release.
 | [v0.0.3](v0.0.3.md) | 2026-04-03 | Intelligence | Released | Diff scorer, state injection, test incentives, backend forcing, Phractal validation |
 | [v0.0.4](v0.0.4.md) | 2026-04-03 | Agent Quality | Released | Category balancing, shift-log tolerance, PR #13 hardening, focus path improvements |
 | [v0.0.5](v0.0.5.md) | 2026-04-03 | Multi-Repo | Released | Multi-repo support, Loop 1 complete at 100% |
-| [v0.0.6](v0.0.6.md) | TBD | Loop 2 Foundation | In progress | Profiler, planner, decomposer, sub-agent, integrator, build CLI |
-| [v0.0.7](v0.0.7.md) | TBD | Security Hardening | In progress | Prompt injection protection for target repos |
+| [v0.0.6](v0.0.6.md) | 2026-04-05 | Loop 2 Foundation | Released | Profiler, planner, decomposer, sub-agent, integrator, build CLI |
+| [v0.0.7](v0.0.7.md) | 2026-04-05 | Security Hardening | Released | Prompt injection, cost tracking, evaluation loop, Loop 2 complete |
+| [v0.0.8](v0.0.8.md) | TBD | Self-Maintaining | In progress | Auto-release, auto-changelog, evaluation CLI |

--- a/docs/changelog/v0.0.6.md
+++ b/docs/changelog/v0.0.6.md
@@ -1,8 +1,8 @@
 # v0.0.6 -- Loop 2 Foundation
 
-**Released**: TBD
+**Released**: 2026-04-05
 **Tag**: `v0.0.6`
-**Status**: In progress
+**Status**: Released
 
 Loop 2 scaffolding begins: repo profiling, feature planning, and the foundation for sub-agent coordination.
 

--- a/docs/changelog/v0.0.7.md
+++ b/docs/changelog/v0.0.7.md
@@ -1,8 +1,8 @@
 # v0.0.7 -- Security Hardening
 
-**Released**: TBD
+**Released**: 2026-04-05
 **Tag**: `v0.0.7`
-**Status**: In progress
+**Status**: Released
 
 Security hardening for running against untrusted target repositories.
 

--- a/docs/changelog/v0.0.8.md
+++ b/docs/changelog/v0.0.8.md
@@ -1,0 +1,17 @@
+# v0.0.8 -- Self-Maintaining
+
+**Released**: TBD
+**Tag**: `v0.0.8`
+**Status**: In progress
+
+Closing the self-maintaining gap: auto-release, auto-changelog, evaluation CLI, and infrastructure automation.
+
+## Added
+
+## Changed
+
+## Fixed
+
+## Removed
+
+## Internal

--- a/docs/tasks/0018.md
+++ b/docs/tasks/0018.md
@@ -1,7 +1,7 @@
 ---
 status: pending
 priority: low
-target: v0.0.6
+target: v0.0.8
 created: 2026-04-03
 completed:
 ---

--- a/docs/tasks/0028.md
+++ b/docs/tasks/0028.md
@@ -3,7 +3,7 @@ status: blocked
 priority: normal
 environment: integration
 blocked_reason: environment
-target: v0.0.7
+target: v0.0.8
 created: 2026-04-03
 completed:
 ---

--- a/docs/tasks/0029.md
+++ b/docs/tasks/0029.md
@@ -3,7 +3,7 @@ status: blocked
 priority: normal
 environment: integration
 blocked_reason: environment
-target: v0.0.7
+target: v0.0.8
 created: 2026-04-03
 completed:
 ---

--- a/docs/tasks/0032.md
+++ b/docs/tasks/0032.md
@@ -2,7 +2,7 @@
 status: pending
 priority: normal
 environment: integration
-target: v0.0.7
+target: v0.0.8
 created: 2026-04-03
 completed:
 ---


### PR DESCRIPTION
## Summary

- Mark v0.0.6 (Loop 2 Foundation) as Released
- Mark v0.0.7 (Security Hardening) as Released
- Retarget blocked integration tasks (#0028, #0029, #0032) from v0.0.7 to v0.0.8
- Retarget profiler enhancement (#0018) from v0.0.6 to v0.0.8
- Create v0.0.8 changelog stub (Self-Maintaining)

## Test plan

- [x] No code changes, docs only
- [x] Changelog README updated with correct dates and status