### PR TITLE
test: cover malformed task frontmatter edge case

### DIFF
--- a/docs/changelog/v0.0.8.md
+++ b/docs/changelog/v0.0.8.md
@@ -22,7 +22,7 @@ Closing the self-maintaining gap: auto-release, auto-changelog, evaluation CLI, 
 
 ## Internal
 - **[meta]** Added `scripts/validate-tasks.sh` as a standalone validator for numbered task files, shipped it through `scripts/install.sh`, and documented it in `CLAUDE.md` / `docs/ops/OPERATIONS.md` so sessions can audit queue frontmatter explicitly instead of discovering corruption only through task scans. (task `#0058`)
-- **[test]** Added 3 regression tests covering valid task sets, malformed/missing frontmatter fields, and invalid enum/date/conditional task metadata. Test suite is now 938 passing.
+- **[test]** Added 4 regression tests covering valid task sets, malformed/missing frontmatter fields, the real missing-closing-delimiter corruption pattern, and invalid enum/date/conditional task metadata. Test suite is now 939 passing.
 - **[meta]** Recorded `docs/evaluations/0012.md`; the latest fresh-clone Phractal run scored `66/100`, confirming that verify-command wiring and clone cleanup remain open while also showing the automated evaluator still under-reads dated shift logs and dirty-clone state.
 - **[meta]** Recorded `docs/evaluations/0011.md`; the latest fresh-clone Phractal run improved to `56/100`, reproduced the remaining verify-command / cleanup / rejected-run-visibility gaps, and provided the exact `Docs/` plus follow-up-commit evidence used to close tasks `#0098` and `#0121`.
 - **[test]** Added 6 regression tests covering `Docs/` repo dry-runs, case-insensitive shift-log verification, bounded shift-log-only commit counts, `Docs/`-aware evaluation artifact parsing, final summary shift-log commits, and the remaining guard rail against unexpected extra code commits. Test suite is now 935 passing.

--- a/docs/handoffs/0056.md
+++ b/docs/handoffs/0056.md
@@ -8,7 +8,7 @@
 - **Step 0 evaluation**: ran the required fresh-clone default Phractal evaluation and wrote `docs/evaluations/0012.md`. The run scored `66/100`, confirmed that `#0099` and `#0100` are still real, and surfaced a scorer-fidelity gap where dirty clones still receive Clean state `10/10`.
 - **Task-queue follow-ups**: created `#0125` for evaluation clean-state scoring fidelity and `#0126` for legacy task files missing `target`.
 - Files: `scripts/validate-tasks.sh`, `scripts/install.sh`, `tests/test_nightshift.py`, `docs/evaluations/0012.md`, `docs/tasks/0058.md`, `docs/tasks/0125.md`, `docs/tasks/0126.md`, `docs/tasks/.next-id`, `docs/changelog/v0.0.8.md`, `docs/vision-tracker/TRACKER.md`, `CLAUDE.md`, `docs/ops/OPERATIONS.md`, `docs/learnings/2026-04-05-standalone-validator-before-ci-gate.md`, `docs/learnings/INDEX.md`, `docs/healer/log.md`
-- Tests: +3 new, 938 total passing (`make check`)
+- Tests: +4 new, 939 total passing (`make check`)
 
 ## Decisions Made
 - **Ship the validator standalone before CI-gating it.** The first real repo run exposed not only the known malformed files (`#0024`, `#0036`, `#0045`) but also seven live task files missing `target`, so wiring `scripts/validate-tasks.sh` into `make check` now would convert known backlog debt into a permanent merge blocker before the repair tasks land.

--- a/docs/handoffs/LATEST.md
+++ b/docs/handoffs/LATEST.md
@@ -8,7 +8,7 @@
 - **Step 0 evaluation**: ran the required fresh-clone default Phractal evaluation and wrote `docs/evaluations/0012.md`. The run scored `66/100`, confirmed that `#0099` and `#0100` are still real, and surfaced a scorer-fidelity gap where dirty clones still receive Clean state `10/10`.
 - **Task-queue follow-ups**: created `#0125` for evaluation clean-state scoring fidelity and `#0126` for legacy task files missing `target`.
 - Files: `scripts/validate-tasks.sh`, `scripts/install.sh`, `tests/test_nightshift.py`, `docs/evaluations/0012.md`, `docs/tasks/0058.md`, `docs/tasks/0125.md`, `docs/tasks/0126.md`, `docs/tasks/.next-id`, `docs/changelog/v0.0.8.md`, `docs/vision-tracker/TRACKER.md`, `CLAUDE.md`, `docs/ops/OPERATIONS.md`, `docs/learnings/2026-04-05-standalone-validator-before-ci-gate.md`, `docs/learnings/INDEX.md`, `docs/healer/log.md`
-- Tests: +3 new, 938 total passing (`make check`)
+- Tests: +4 new, 939 total passing (`make check`)
 
 ## Decisions Made
 - **Ship the validator standalone before CI-gating it.** The first real repo run exposed not only the known malformed files (`#0024`, `#0036`, `#0045`) but also seven live task files missing `target`, so wiring `scripts/validate-tasks.sh` into `make check` now would convert known backlog debt into a permanent merge blocker before the repair tasks land.

--- a/docs/vision-tracker/TRACKER.md
+++ b/docs/vision-tracker/TRACKER.md
@@ -37,7 +37,7 @@ The core loop still works on the happy path, and the latest runner hardening fix
 | Path bias detection | Done | ████████████████████ 100% |
 | Hot-file protection | Done | ████████████████████ 100% |
 | Halt conditions | Done | ████████████████████ 100% |
-| Test suite (938 tests) | Done | ████████████████████ 100% |
+| Test suite (939 tests) | Done | ████████████████████ 100% |
 | Post-cycle diff scorer | Done | ████████████████████ 100% |
 | Cycle-to-cycle state injection | Done | ████████████████████ 100% |
 | Test writing incentives | Done | ████████████████████ 100% |

--- a/tests/test_nightshift.py
+++ b/tests/test_nightshift.py
@@ -9296,6 +9296,26 @@ class TestValidateTasksScript:
         assert "0003.md: frontmatter line 2: invalid field '## status'" in result.stdout
         assert "0003.md: status: missing" in result.stdout
 
+    def test_reports_missing_closing_frontmatter_delimiter(self, tmp_path: Path) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        script = repo_root / "scripts" / "validate-tasks.sh"
+        task_dir = tmp_path / "tasks"
+        task_dir.mkdir()
+        (task_dir / "0004.md").write_text(
+            "---\nstatus: pending\npriority: low\ntarget: v0.0.8\ncreated: 2026-04-05\n\n# Broken task\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            ["bash", str(script), str(task_dir)],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+
+        assert result.returncode != 0
+        assert "0004.md: frontmatter: missing closing --- delimiter" in result.stdout
+
     def test_reports_invalid_status_priority_dates_and_conditional_fields(self, tmp_path: Path) -> None:
         repo_root = Path(__file__).resolve().parent.parent
         script = repo_root / "scripts" / "validate-tasks.sh"


### PR DESCRIPTION
## Summary
- add the missing regression for task files with an opening frontmatter delimiter and no closing delimiter
- update the shipped test-count references to match the new `make check` total

## Test plan
- make check
- python3 -m pytest tests/test_nightshift.py -k missing_closing -v