### PR TITLE
docs: accuracy sweep — all docs updated for pick-role.py architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ python3 -m nightshift module-map --write   # refresh docs/architecture/MODULE_MA
 
 One unified daemon that picks its own role each cycle. Full guide: `docs/ops/DAEMON.md`
 
-Each cycle the agent reads system signals (eval scores, task queue size, session history) and scores four roles. The highest score wins:
+Each cycle `scripts/pick-role.py` reads system signals (eval scores, task queue size, session history) and scores five roles. The highest score wins:
 - **BUILD**: picks up tasks, builds features, PRs, merges. Includes pentest preflight and healer observations.
 - **REVIEW**: reviews code file by file, fixes quality issues. Triggered after 5+ consecutive builds.
 - **OVERSEE**: audits task queue, fixes priorities, culls stale tasks. Triggered when 50+ pending tasks accumulate.

--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@
 
 ## This repo maintains itself
 
-Most of the code in this repository was written, tested, reviewed, and merged by AI agents. The control plane currently has four daemon entry points:
+Most of the code in this repository was written, tested, reviewed, and merged by AI agents. One unified daemon (`scripts/daemon.sh`) auto-selects from five roles each cycle via `scripts/pick-role.py`:
 
 - **Builder**: reads the task queue, runs a pentest preflight, builds or fixes one scoped task, tests it, opens a PR, reviews it, and merges it
 - **Reviewer**: audits shipped code and fixes quality gaps
 - **Overseer**: audits process drift, task hygiene, and systemic issues
 - **Strategist**: produces a top-down health report for humans
+- **Achiever**: measures autonomy score (0-100), eliminates human dependencies
 
-The human role is operational: start a daemon, monitor it, and redirect when priorities change. The agents own the engineering loop.
+The human role is operational: start the daemon and monitor it. The agents own the engineering loop -- including deciding what to work on.
 
 **Proof points live in the repo, not in marketing copy.** Check them directly:
 

--- a/docs/ops/ROLE-SCORING.md
+++ b/docs/ops/ROLE-SCORING.md
@@ -1,8 +1,8 @@
-# Nightshift Unified Daemon Prompt
+# Role Scoring Reference
 
-You are a senior autonomous systems engineer responsible for the Nightshift codebase. You self-direct across four capabilities: building features, reviewing code quality, overseeing the task queue, and strategic planning. Each session, you assess what the system needs most and act in that role.
+This document describes how `scripts/pick-role.py` decides which role the daemon runs each cycle. It is reference documentation, not an active prompt. The scoring engine in `pick-role.py` implements these rules in Python.
 
-Begin your response with the SYSTEM SIGNALS block. Do not write any preamble before it.
+The daemon has five roles: BUILD, REVIEW, OVERSEE, STRATEGIZE, ACHIEVE. Each cycle, the scoring engine reads system signals and picks the highest-scoring role.
 
 <context>
 Nightshift is an autonomous engineering system. The repo contains:

--- a/docs/prompt/achieve.md
+++ b/docs/prompt/achieve.md
@@ -71,11 +71,11 @@ Read these files and compute the autonomy score. Do this EVERY session before fi
 
 | Check | Points | How to verify |
 |-------|--------|---------------|
-| Unified daemon picks its own role each cycle | 5 | Check: does `unified.md` exist? Is `daemon.sh` loading it? |
+| Unified daemon picks its own role each cycle | 5 | Check: does `scripts/pick-role.py` exist? Is `daemon.sh` calling it? |
 | Task queue self-generates from system observation | 5 | Check: does `evolve.md` Step 6o (Generate Work) exist? Are tasks being created? |
 | Releases cut automatically (no release tasks needed) | 5 | Check: does `evolve.md` Step 11 have the release algorithm? Has it released anything? (check `git tag`) |
 | Stale tasks get attention (staleness multiplier or overseer culling) | 5 | Check: do stale tasks eventually get picked or culled? (check task archive) |
-| Strategy reviews trigger automatically (not manually) | 5 | Check: does `unified.md` scoring trigger STRATEGIZE? Has it run? (check `docs/strategy/`) |
+| Strategy reviews trigger automatically (not manually) | 5 | Check: does `scripts/pick-role.py` scoring trigger STRATEGIZE? Has it run? (check `docs/strategy/`) |
 
 ### Self-Validating (25 points)
 

--- a/docs/prompt/overseer.md
+++ b/docs/prompt/overseer.md
@@ -5,13 +5,14 @@ You are the overseer of the Nightshift autonomous engineering system. You do NOT
 Your job is to look at the task queue, the handoffs, the learnings, the session history, the PRs, and the evaluations — and fix systemic issues that the builder daemon cannot see because it's heads-down on one task at a time.
 
 <context>
-Nightshift runs a unified daemon (`daemon.sh`) that picks its role each cycle:
+Nightshift runs a unified daemon (`daemon.sh`) where `scripts/pick-role.py` picks the role each cycle:
 - **BUILD**: picks up tasks, builds features, ships code
 - **REVIEW**: reviews code file by file, fixes quality
 - **OVERSEE**: this is you -- audit the system
 - **STRATEGIZE**: big picture review, advises human
+- **ACHIEVE**: measures autonomy score, eliminates human dependencies
 
-You were selected as **OVERSEE** this cycle by the unified prompt's scoring. Each cycle you:
+You were selected as **OVERSEE** this cycle by the scoring engine. Each cycle you:
 1. Audit the task queue
 2. Audit the handoffs and learnings
 3. Fix what's wrong

--- a/docs/prompt/strategist.md
+++ b/docs/prompt/strategist.md
@@ -3,13 +3,14 @@
 You are the strategic advisor for the Nightshift autonomous engineering system. You do NOT build features. You do NOT fix code. You look at the big picture and tell the human what's working, what's broken, and what should change.
 
 <context>
-Nightshift runs a unified daemon (`daemon.sh`) that picks its role each cycle:
+Nightshift runs a unified daemon (`daemon.sh`) where `scripts/pick-role.py` picks the role each cycle:
 - **BUILD** (evolve.md): picks up tasks, builds features, ships code
 - **REVIEW** (review.md): reviews code file by file, fixes quality issues
 - **OVERSEE** (overseer.md): audits task queue, fixes priorities, cleans duplicates
 - **STRATEGIZE** (strategist.md): this is you -- big picture review
+- **ACHIEVE** (achieve.md): measures autonomy score, eliminates human dependencies
 
-You were selected as **STRATEGIZE** this cycle by the unified prompt's scoring. Your job is to evaluate whether the SYSTEM ITSELF is working -- not the code it produces, but the process, the prompts, the task queue, the evaluation loop, the decision-making. The OVERSEE role handles tactical fixes (duplicate tasks, wrong priorities). You handle strategic questions (are we building the right things? is the architecture sound? should we change direction?).
+You were selected as **STRATEGIZE** this cycle by the scoring engine. Your job is to evaluate whether the SYSTEM ITSELF is working -- not the code it produces, but the process, the prompts, the task queue, the evaluation loop, the decision-making. The OVERSEE role handles tactical fixes (duplicate tasks, wrong priorities). You handle strategic questions (are we building the right things? is the architecture sound? should we change direction?).
 </context>
 
 <rules>


### PR DESCRIPTION
## Summary
Fix stale references across 6 files after the unified prompt → pick-role.py migration:

- achieve.md: unified.md → pick-role.py in scorecard verification
- overseer.md + strategist.md: added ACHIEVE to role lists, fixed scoring reference
- ROLE-SCORING.md: reframed as reference doc (was still written as "You are..." active prompt)
- CLAUDE.md: "four roles" → "five roles"
- README.md: "four daemon entry points" → one unified daemon with five roles

DAEMON.md full rewrite deferred as a task for the daemon (100+ stale lines).