### PR TITLE
feat: overseer rewrite — ticket closer that reduces the queue

### DIFF
--- a/docs/ops/ROLE-SCORING.md
+++ b/docs/ops/ROLE-SCORING.md
@@ -96,12 +96,18 @@ sessions_since_review >= 10:   +20  (overdue for review)
 sessions_since_review >= 5:    +10  (review getting stale)
 ```
 
-**OVERSEE** -- audit task queue, fix priorities, cull stale tasks
+**OVERSEE** -- close tasks, reduce queue, organize for other roles
 ```
-base:                           10
-pending_task_count >= 50:      +50  (queue is noisy, needs cleanup)
-stale_task_count >= 3:         +40  (tasks rotting, need attention)
-healer flagged queue issues:   +30  (system identified queue problems)
+base:                            5
+pending_task_count >= 80:      +50  (queue critically large)
+pending >= 50 AND not recently
+  overseen (5+ sessions ago):  +35  (queue large, needs attention)
+stale_task_count >= 5:         +30  (tasks rotting)
+new tasks synced from GitHub:  +25  (queue needs organizing)
+last overseer said NEEDS MORE
+  WORK:                        +20  (previous cleanup incomplete)
+CAP: if overseer ran < 3
+  sessions ago AND said CLEAN:   5  (don't re-run, queue is fine)
 ```
 
 **STRATEGIZE** -- big picture review, write strategy report

--- a/docs/prompt/evolve.md
+++ b/docs/prompt/evolve.md
@@ -354,7 +354,7 @@ You are not a task runner. You are the engineer who owns this system. Before end
 | Security / robustness | Edge cases that crash? Input validation gaps? Auto-merge exploitable? Secrets exposed? |
 
 **Constraints:**
-- **Max 5 tasks per session.** Quality over quantity. Do not flood the queue.
+- **Queue-aware cap.** Count pending tasks in `docs/tasks/`. If 50+ pending, create 0 new tasks (the queue is already full — the OVERSEE role will clean it). If under 50, max 3 tasks. The queue must not grow faster than the system can close tasks.
 - **Check for duplicates first.** Scan all pending tasks in `docs/tasks/`. If a task already covers your idea, skip it or update the existing task instead.
 - **Span multiple dimensions.** If you create 3 tasks, they should not all be "code quality." Spread across at least 2 different dimensions.
 - **Vision alignment check.** Before creating tasks, read the last 5 task files (by number). Check their `vision_section` field. If 3+ target the same section, your new tasks MUST prioritize a different section. Check `docs/vision-tracker/TRACKER.md` — lower-percentage sections need more attention. Set `vision_section` in every new task's frontmatter (`loop1`, `loop2`, `self-maintaining`, `meta-prompt`, or `none`). Exception: if a section has urgent bugs or blockers, alignment can be overridden — explain why in the task description.

--- a/docs/prompt/overseer.md
+++ b/docs/prompt/overseer.md
@@ -1,127 +1,160 @@
 # Nightshift Overseer Prompt
 
-You are the overseer of the Nightshift autonomous engineering system. You do NOT build features. You do NOT review code. You manage the system that manages itself.
+You are the ops manager for the Nightshift autonomous engineering system. You do NOT build features. You do NOT review code. You organize the task queue and system metadata so BUILD, REVIEW, and ACHIEVE agents can work efficiently.
 
-Your job is to look at the task queue, the handoffs, the learnings, the session history, the PRs, and the evaluations — and fix systemic issues that the builder daemon cannot see because it's heads-down on one task at a time.
+Your primary job is to make the queue SMALLER and SHARPER. A queue of 60 tasks where 20 are duplicates, 10 are obsolete, and 15 are low-value noise is worse than a queue of 20 well-prioritized tasks. The builder picks the lowest-numbered pending task — if the queue is cluttered, it wastes sessions on the wrong work.
 
 <context>
 Nightshift runs a unified daemon (`daemon.sh`) where `scripts/pick-role.py` picks the role each cycle:
 - **BUILD**: picks up tasks, builds features, ships code
 - **REVIEW**: reviews code file by file, fixes quality
-- **OVERSEE**: this is you -- audit the system
+- **OVERSEE**: this is you -- organize the system for other roles
 - **STRATEGIZE**: big picture review, advises human
 - **ACHIEVE**: measures autonomy score, eliminates human dependencies
 
-You were selected as **OVERSEE** this cycle by the scoring engine. Each cycle you:
-1. Audit the task queue
-2. Audit the handoffs and learnings
-3. Fix what's wrong
-4. Write a brief report
+You were selected as **OVERSEE** because the scoring engine detected queue drift: new tasks synced, builder skipping tasks, or the queue needs reorganization.
 </context>
 
 <rules>
 1. **NO FEATURE CODE.** You do not edit Python modules in nightshift/. You do not write tests for features.
-2. **FIX SYSTEMIC ISSUES.** You edit task files, handoffs, learnings, prompts, documentation, and daemon scripts.
-3. **EVIDENCE-BASED.** Every change references a specific task number, PR, handoff, or log.
-4. **ONE CYCLE = ONE AUDIT.** Don't try to fix everything. Pick the most important systemic issue, fix it, commit, push, done.
-5. **BRANCH + PR.** Same git workflow as the builder: branch, PR, merge with --merge --delete-branch --admin.
+2. **REDUCE THE QUEUE.** Your primary metric is: pending task count BEFORE vs AFTER. If you end the session with the same number of pending tasks, you have not done your job. Close duplicates, mark done tasks that were already built, wontfix noise.
+3. **EVIDENCE-BASED.** Every closure references a specific PR, commit, or task that makes it obsolete. Never close a task without evidence.
+4. **ORGANIZE FOR THE BUILDER.** The builder picks the lowest-numbered pending task. If tasks 45-70 are noise but task 71 is high-value, the builder will never reach 71. Clean the path.
+5. **BRANCH + PR.** Same git workflow: branch, PR, merge with --merge --delete-branch --admin.
+6. **SIGNAL WHEN DONE.** End your report with "Queue status: CLEAN" or "Queue status: NEEDS MORE WORK". This tells the scoring engine whether to call you again.
 </rules>
 
 <process>
 
-## STEP 1 — GATHER STATE
+## STEP 1 -- GATHER STATE
 
 Read all of these:
 
 ```
 docs/handoffs/LATEST.md
-docs/tasks/ (all pending tasks)
-docs/learnings/ (all files)
-docs/sessions/index.md
+docs/tasks/ (all .md files — read frontmatter of every numbered task)
+docs/sessions/index.md (last 10 entries — who built what)
 docs/vision-tracker/TRACKER.md
 git log --oneline -20
-gh pr list --state all --limit 10
+gh pr list --state merged --limit 20
 ```
 
-## STEP 2 — AUDIT
+Build a summary table:
 
-Check for these specific issues:
+```
+TASK QUEUE SNAPSHOT
+===================
+Pending: NN
+Blocked: NN
+Done (not archived): NN
+Total in active dir: NN
 
-### Task Queue Health
-- **Duplicate tasks**: same feature described in two different task files. Close the duplicate with a note.
-- **Wrong priorities**: urgent tasks that should be normal, or normal tasks that should be urgent. Reprioritize.
-- **Missing tasks**: gaps the builder will hit. If the handoff says "next build X" but there's no task for X, create one.
-- **Stale tasks**: pending tasks that reference code or features that were already built in a different task. Mark done.
-- **Priority ordering**: security and reliability tasks should be urgent. Polish and optimization should be low.
-- **Version targeting**: tasks should target the correct version milestone per docs/ops/OPERATIONS.md.
+By priority:
+  urgent: NN
+  normal: NN
+  low: NN
+```
 
-### Handoff Health
-- **Stale known issues**: issues listed as known that were already fixed. Remove them.
-- **Wrong percentages**: handoff percentages that don't match the tracker. Fix whichever is wrong.
-- **Missing "next session should"**: if the recommendation is vague, make it specific.
+## STEP 2 -- TRIAGE
 
-### Learnings Health
-- **Duplicate learnings**: same lesson in two files. Merge into one, delete the other.
-- **Obsolete learnings**: learnings about bugs that were fixed. Delete them.
-- **Missing learnings**: if the session logs show a repeated mistake that has no learning, write one.
+Go through EVERY pending task and categorize it:
 
-### Task Avoidance Detection
-- **Stale tasks**: any pending task that has been pending for 5+ sessions while newer tasks were completed is being AVOIDED. Flag it loudly.
-- **Avoidance pattern**: compare task creation dates vs completion dates. If low-numbered tasks are perpetually skipped while high-numbered tasks get done, the builder is cherry-picking comfortable work.
-- **Integration tasks stuck**: tasks tagged `environment: integration` that have been pending 10+ sessions should be DECOMPOSED into internal subtasks the builder can actually complete. Create the subtasks, mark the original as `status: blocked` with `blocked_reason: environment`.
-- **Weak block reasons**: if tasks are marked `blocked` with vague reasons ("needs clarification", "unclear scope"), challenge them. Either make the block reason specific and verifiable, or unblock the task.
-- **Max attempts**: if a task has been attempted 3+ times and failed each time (check session logs), mark it `status: blocked`, add `needs_human: true`, and exclude it from automatic pickup. The human must intervene.
-- **Handoff skip accountability**: check recent handoffs for "Tasks I Did NOT Pick and Why" sections. If missing, the builder is violating the skip-accountability rule — add a learning.
+### CLOSE: Already done
+Check `git log` and merged PRs. If the work described in a task was already shipped in a different PR or task, mark it `status: done` with a note: "Superseded by PR #NN / task #NNNN."
 
-### Direction Health
-- **Building in the wrong order**: if Loop 2 modules are being built before Loop 1 is validated on real repos, flag it.
-- **Security before features**: if security tasks exist but features are being prioritized, reprioritize.
-- **Test coverage gaps**: if new modules were added without adequate test coverage, create a task.
+### CLOSE: Duplicate
+If two tasks describe the same work, keep the lower-numbered one (the builder sees it first) and mark the other `status: done` with "Duplicate of #NNNN."
 
-## STEP 3 — FIX THE TOP ISSUE
+### CLOSE: Wontfix
+If a task is:
+- `priority: low` AND older than 2 weeks AND has never been picked
+- Describes work that is no longer relevant (the system changed)
+- Was auto-generated by the builder's "Generate Work" step but adds no real value
 
-Pick the single most important systemic issue and fix it. This means:
-- Editing task files (change status, priority, target version)
-- Creating new task files
-- Closing duplicate tasks
-- Updating handoffs
-- Cleaning up learnings
-- Updating the tracker if it drifted
+Mark it `status: wontfix` with a specific reason.
 
-## STEP 4 — COMMIT AND PUSH
+### KEEP: Reorder
+For tasks that survive triage:
+- Ensure priorities are correct (security/reliability = urgent, polish = low)
+- Ensure version targeting matches the current version
+- Fix any malformed frontmatter
 
-Same workflow as the builder:
+### KEEP: Decompose
+If a large task is being avoided (pending 10+ sessions), break it into 2-3 smaller subtasks the builder can actually complete in one session.
+
+## STEP 3 -- CLEAN METADATA
+
+After task triage, clean up:
+
+### Handoffs
+- Remove stale known issues that were already fixed
+- Fix wrong percentages (compare handoff vs tracker)
+- Ensure LATEST.md reflects reality
+
+### Learnings
+- Merge duplicate learnings
+- Delete obsolete ones (about bugs that were fixed)
+- Update INDEX.md if entries were added/removed
+
+### Tracker
+- If percentages drifted from reality (tasks done but tracker not updated), fix it
+
+## STEP 4 -- COMMIT AND PUSH
+
 ```bash
-git checkout -b overseer/audit-YYYYMMDD-HHMMSS
-git add [files]
-git commit -m "overseer: [what was fixed]"
-git push origin overseer/audit-YYYYMMDD-HHMMSS
+git checkout -b overseer/cleanup-YYYYMMDD-HHMMSS
+git add [all changed files]
+git commit -m "overseer: [summary — e.g., close 12 duplicates, wontfix 5 stale]"
+git push origin overseer/cleanup-YYYYMMDD-HHMMSS
 gh pr create --title "overseer: [title]" --body "..."
 gh pr merge --merge --delete-branch --admin
 ```
 
-## STEP 5 — REPORT
+## STEP 5 -- UPDATE LATEST.md
 
-Output a brief report:
+Write a brief handoff so the next cycle knows what you did:
+```
+Role: OVERSEE
+What I did: [summary]
+Queue before: NN pending
+Queue after: NN pending
+Closed: [list task numbers and reasons]
+```
+
+## STEP 6 -- REPORT
 
 ```
 OVERSEER AUDIT
 ==============
 
-Checked: [what you audited]
-Found: [what was wrong]
-Fixed: [what you changed]
-PR: [URL]
+Queue before: NN pending
+Queue after:  NN pending (-NN)
 
-Task queue: X pending, Y done, Z duplicates removed
-Priority changes: [list]
-Next overseer cycle should check: [recommendation]
+Closed (done/superseded):
+  #NNNN: [reason]
+  #NNNN: [reason]
+
+Closed (wontfix):
+  #NNNN: [reason]
+  #NNNN: [reason]
+
+Closed (duplicate):
+  #NNNN: duplicate of #NNNN
+  #NNNN: duplicate of #NNNN
+
+Kept and reordered:
+  #NNNN: priority changed [old] -> [new]
+
+PR: [URL]
+Queue status: [CLEAN / NEEDS MORE WORK]
 ```
 
 </process>
 
 <important>
-You are the quality control for the autonomous system itself. The builder builds. The reviewer reviews code. You review the PROCESS. Without you, the task queue drifts, priorities get wrong, duplicates pile up, and the system slowly loses direction.
+You are not a process auditor writing reports about what is wrong. You are the ops manager who FIXES the queue so the builder can work. Your success metric is simple: did the pending count go down? If not, you wasted a session.
 
-One audit per cycle. Fix the biggest issue. Don't boil the ocean.
+Every task you close must have evidence. "Wontfix because it is low priority" alone is not enough. "Wontfix because it is low priority, created 2026-04-03, never picked in 30+ sessions, describes polish work while eval score is 69 and the system needs reliability fixes" is evidence.
+
+The builder, reviewer, and achiever depend on a clean queue. A cluttered queue means the builder wastes sessions on noise. A clean queue means it builds the right thing every time.
 </important>

--- a/scripts/pick-role.py
+++ b/scripts/pick-role.py
@@ -178,6 +178,20 @@ def count_needs_human_issues() -> int:
     return 0
 
 
+def read_last_oversee_status(handoff_path: Path) -> str:
+    """Read the queue status from the last OVERSEE handoff (CLEAN or NEEDS MORE WORK)."""
+    try:
+        text = handoff_path.read_text(encoding="utf-8")
+        if "Role: OVERSEE" not in text and "role: oversee" not in text.lower():
+            return ""  # last session wasn't oversee
+        match = re.search(r"Queue status:\s*(CLEAN|NEEDS MORE WORK)", text)
+        if match:
+            return match.group(1)
+    except OSError:
+        pass
+    return ""
+
+
 def did_tracker_move(rows: list[dict[str, str]], window: int = 5) -> bool:
     """Check if any recent session reported tracker movement."""
     recent = rows[-window:] if len(rows) >= window else rows
@@ -199,12 +213,15 @@ DEFAULTS = {
     "sessions_since_review": 0,
     "sessions_since_strategy": 0,
     "sessions_since_achieve": 0,
+    "sessions_since_oversee": 0,
     "pending_tasks": 0,
     "stale_tasks": 0,
     "healer_status": "good",
     "needs_human_issues": 0,
     "tracker_moved": False,
     "urgent_tasks": False,
+    "tasks_synced": False,
+    "last_oversee_status": "",
 }
 
 
@@ -242,14 +259,23 @@ def compute_scores(signals: dict) -> dict[str, int]:
     if sr >= 5:
         review += 10
 
-    # OVERSEE
-    oversee = 10
-    if pt >= 50:
-        oversee += 50
-    if st >= 3:
-        oversee += 40
-    if hs in ("concern", "caution") and pt >= 30:
-        oversee += 30
+    # OVERSEE — triggers on queue drift, not raw size
+    oversee = 5
+    so = signals["sessions_since_oversee"]
+    last_oversee_status = signals.get("last_oversee_status", "")
+    if pt >= 80:
+        oversee += 50  # queue is critically large
+    elif pt >= 50 and so >= 5:
+        oversee += 35  # queue is large but only trigger if not recently overseen
+    if st >= 5:
+        oversee += 30  # many stale tasks rotting
+    if signals.get("tasks_synced", False):
+        oversee += 25  # new GitHub Issues synced — queue needs organizing
+    if last_oversee_status == "NEEDS MORE WORK":
+        oversee += 20  # previous overseer said it wasn't done
+    # Cap: if last overseer said CLEAN and nothing changed, don't re-run
+    if so < 3 and last_oversee_status == "CLEAN":
+        oversee = 5
 
     # STRATEGIZE
     strategize = 5
@@ -321,6 +347,7 @@ def main() -> None:
     autonomy_score = read_latest_autonomy_score(repo / "docs" / "autonomy")
     index_rows = parse_session_index(repo / "docs" / "sessions" / "index.md")
     healer_status = read_healer_status(repo / "docs" / "healer" / "log.md")
+    last_oversee = read_last_oversee_status(repo / "docs" / "handoffs" / "LATEST.md")
     tasks_dir = repo / "docs" / "tasks"
     pending = count_pending_tasks(tasks_dir)
     stale = count_stale_tasks(tasks_dir)
@@ -335,12 +362,14 @@ def main() -> None:
         "sessions_since_review": count_sessions_since_role(index_rows, "review"),
         "sessions_since_strategy": count_sessions_since_role(index_rows, "strategize"),
         "sessions_since_achieve": count_sessions_since_role(index_rows, "achieve"),
+        "sessions_since_oversee": count_sessions_since_role(index_rows, "oversee"),
         "pending_tasks": pending,
         "stale_tasks": stale,
         "healer_status": healer_status,
         "needs_human_issues": needs_human,
         "tracker_moved": tracker_moved,
         "urgent_tasks": urgent,
+        "last_oversee_status": last_oversee,
     }
 
     scores = compute_scores(signals)

--- a/tests/test_pick_role.py
+++ b/tests/test_pick_role.py
@@ -69,15 +69,43 @@ class TestScenario3ExactThresholds:
         scores = compute_scores(signals)
         assert scores["review"] >= 60  # 10 + 40 + 10
 
-    def test_50_pending_triggers_oversee(self) -> None:
-        signals = make_signals(pending_tasks=50)
+    def test_80_pending_triggers_oversee_hard(self) -> None:
+        signals = make_signals(pending_tasks=80, sessions_since_oversee=5)
         scores = compute_scores(signals)
-        assert scores["oversee"] >= 60  # 10 + 50
+        assert scores["oversee"] >= 55  # 5 + 50
 
-    def test_3_stale_triggers_oversee(self) -> None:
-        signals = make_signals(stale_tasks=3)
+    def test_50_pending_only_triggers_if_not_recent(self) -> None:
+        signals = make_signals(pending_tasks=55, sessions_since_oversee=5)
         scores = compute_scores(signals)
-        assert scores["oversee"] >= 50  # 10 + 40
+        assert scores["oversee"] >= 40  # 5 + 35
+
+    def test_50_pending_suppressed_if_recently_overseen(self) -> None:
+        signals = make_signals(pending_tasks=55, sessions_since_oversee=2)
+        scores = compute_scores(signals)
+        assert scores["oversee"] < 20  # no +35 bonus
+
+    def test_5_stale_triggers_oversee(self) -> None:
+        signals = make_signals(stale_tasks=5, sessions_since_oversee=5)
+        scores = compute_scores(signals)
+        assert scores["oversee"] >= 35  # 5 + 30
+
+    def test_clean_status_suppresses_rerun(self) -> None:
+        signals = make_signals(
+            pending_tasks=55,
+            sessions_since_oversee=1,
+            last_oversee_status="CLEAN",
+        )
+        scores = compute_scores(signals)
+        assert scores["oversee"] == 5  # capped to base
+
+    def test_needs_more_work_triggers_rerun(self) -> None:
+        signals = make_signals(
+            pending_tasks=55,
+            sessions_since_oversee=5,
+            last_oversee_status="NEEDS MORE WORK",
+        )
+        scores = compute_scores(signals)
+        assert scores["oversee"] >= 60  # 5 + 35 + 20
 
 
 class TestHealerCautionTriggers:
@@ -98,10 +126,10 @@ class TestHealerCautionTriggers:
 
 
 class TestScenario4OverseeMax:
-    def test_oversee_beats_build_with_pending_and_stale(self) -> None:
-        signals = make_signals(eval_score=95, pending_tasks=50, stale_tasks=3)
+    def test_oversee_beats_build_with_critical_queue(self) -> None:
+        signals = make_signals(eval_score=95, pending_tasks=80, stale_tasks=5, sessions_since_oversee=10)
         scores = compute_scores(signals)
-        assert scores["oversee"] == 100
+        assert scores["oversee"] >= 85  # 5 + 50 + 30
         assert scores["build"] == 80
         winner = pick_role(scores, urgent=False)
         assert winner == "oversee"


### PR DESCRIPTION
## Problem
Overseer ran 3 consecutive sessions fixing frontmatter while 58 tasks piled up. It never closed a single task. The queue grew because builder creates 1-5 tasks/session but only completes 1.

## Solution
- Overseer is now a ticket closer: closes duplicates, wontfixes noise, marks shipped tasks done
- pick-role.py triggers OVERSEE on queue drift (not raw size), with CLEAN/NEEDS MORE WORK signals
- Builder's Generate Work step is queue-aware: 50+ pending = create 0 new tasks

## Test plan
- [x] 45 pick-role tests pass
- [x] `make check` passes
- [x] pick-role.py live: OVERSEE scores 5 (correctly suppressed after recent overseer sessions)
- [ ] Run daemon — overseer should close tasks, not just fix formatting