### PR TITLE
fix: harden orbitweb notification workflow

### DIFF
--- a/.github/workflows/notify-orbitweb.yml
+++ b/.github/workflows/notify-orbitweb.yml
@@ -4,12 +4,18 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: nightshift-sync
+  cancel-in-progress: true
+
 jobs:
   create-sync-issue:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Create sync issue on Orbit-web
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.ORBITWEB_PAT }}
           script: |
@@ -17,20 +23,24 @@ jobs:
             const commitMsg = context.payload.head_commit?.message?.split('\n')[0] || 'unknown';
             const commitUrl = `https://github.com/Recusive/Nightshift/commit/${context.sha}`;
 
-            await github.rest.issues.create({
-              owner: 'Recusive',
-              repo: 'Orbit-web',
-              title: `nightshift-sync: ${commitMsg}`,
-              body: [
-                '## Nightshift repo updated',
-                '',
-                `**Commit:** [\`${commitSha}\`](${commitUrl})`,
-                `**Message:** ${commitMsg}`,
-                `**Pushed by:** ${context.actor}`,
-                '',
-                'The `/nightshift` page on orbit.build should be synced with the latest repo state.',
-                '',
-                '_This issue was created automatically by the Nightshift CI pipeline._',
-              ].join('\n'),
-              labels: ['nightshift-sync'],
-            });
+            try {
+              await github.rest.issues.create({
+                owner: 'Recusive',
+                repo: 'Orbit-web',
+                title: `nightshift-sync: ${commitMsg}`,
+                body: [
+                  '## Nightshift repo updated',
+                  '',
+                  `**Commit:** [\`${commitSha}\`](${commitUrl})`,
+                  `**Message:** ${commitMsg}`,
+                  `**Pushed by:** ${context.actor}`,
+                  '',
+                  'The `/nightshift` page on orbit.build should be synced with the latest repo state.',
+                  '',
+                  '_This issue was created automatically by the Nightshift CI pipeline._',
+                ].join('\n'),
+                labels: ['nightshift-sync'],
+              });
+            } catch (error) {
+              core.setFailed(`Failed to create sync issue: ${error.message}`);
+            }


### PR DESCRIPTION
## Summary
- Pin `actions/github-script` to SHA for supply chain security
- Add concurrency group to prevent duplicate sync issues on rapid pushes
- Scope permissions to `contents:read` (least privilege)
- Wrap issue creation in try/catch with `core.setFailed`

## Test plan
- [ ] Verify workflow triggers on next push to main
- [ ] Confirm sync issue is created on Orbit-web