### PR TITLE
docs: add learning for security function exit code pattern

### DIFF
--- a/docs/learnings/2026-04-06-pentest-revert-exit-codes.md
+++ b/docs/learnings/2026-04-06-pentest-revert-exit-codes.md
@@ -1,0 +1,36 @@
+---
+date: 2026-04-06
+session: 0073
+type: security
+topic: pentest-revert-exit-codes
+---
+
+# Shell security functions need distinct exit codes for partial success
+
+## Observation
+
+`check_origin_integrity` returned the same exit code (1) for "tampered but
+reverted" and "tampered but revert FAILED". The caller (`daemon.sh`) could not
+distinguish between the two states and called `reset_repo_state` in both cases.
+In the failure case, this pulled compromised content into the working tree.
+
+## Rule
+
+When a security function has multiple outcomes that require different caller
+behavior, use distinct exit codes for each:
+
+- 0: clean / no action needed
+- 1: action taken, problem resolved (caller can proceed normally)
+- 2: action attempted, failed (caller must abort)
+
+`if ! fn; then ...` only distinguishes 0 vs non-zero. If the caller needs to
+differentiate non-zero outcomes, capture `$?` explicitly.
+
+## How to apply
+
+Any shell function that attempts a remediation and may fail silently should:
+1. Track remediation success with a local variable (`revert_ok=0`)
+2. Set it on success (`revert_ok=1`)
+3. Return a distinct "failed" code (2) when the remediation did not complete
+
+Callers must use `fn; STATUS=$?; if [ "$STATUS" -eq 2 ]` not `if ! fn`.

--- a/docs/learnings/INDEX.md
+++ b/docs/learnings/INDEX.md
@@ -40,6 +40,7 @@ Read this file FIRST. Only open individual learning files when they are relevant
 
 - [Shell injection: env var pattern](2026-04-06-shell-injection-env-var-pattern.md) — Pass agent-controlled text via env vars into `python3 -c`, never by string interpolation; applies to any value extracted from agent output
 - [Prompt guard origin blind spot](2026-04-06-prompt-guard-origin-blind-spot.md) — Working-tree-only guards miss remote pushes; record `origin/main` hash before cycle and compare after; use `git init -b main --bare` in tests or attacker push is rejected
+- [Security functions need distinct exit codes](2026-04-06-pentest-revert-exit-codes.md) — Return 0/1/2 for clean/fixed/failed; callers using `if !` cannot distinguish remediation success from failure
 
 ## Code Patterns
 


### PR DESCRIPTION
Adds learning from session #0073: security shell functions need distinct exit codes (0/1/2) for clean/fixed/failed so callers can abort on partial failure.