### PR TITLE
fix: prompt guard distinguishes PR merges from direct pushes

### DIFF
--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -229,8 +229,12 @@ ${PENTEST_PROMPT}"
     if ! check_prompt_integrity "$REPO_DIR" "$SNAP_DIR" "$PROMPT_ALERT"; then
         echo "  Pentest preflight modified prompt/control files; reset to origin/main and alerting builder."
     fi
-    if ! check_origin_integrity "$REPO_DIR" "$SNAP_DIR" "$PROMPT_ALERT"; then
+    check_origin_integrity "$REPO_DIR" "$SNAP_DIR" "$PROMPT_ALERT"
+    local origin_rc=$?
+    if [ "$origin_rc" -eq 1 ]; then
         echo "  Pentest preflight pushed prompt/control files to origin/main; reverted and alerting builder."
+    elif [ "$origin_rc" -eq 2 ]; then
+        echo "  CRITICAL: Pentest pushed to origin/main and revert FAILED. Resetting to origin/main."
     fi
     cleanup_prompt_snapshots "$SNAP_DIR"
     reset_repo_state
@@ -305,8 +309,12 @@ ${PROMPT}"
     if ! check_prompt_integrity "$REPO_DIR" "$SNAP_DIR" "$PROMPT_ALERT"; then
         PROMPT_TAMPERED=" [PROMPT MODIFIED]"
     fi
-    if ! check_origin_integrity "$REPO_DIR" "$SNAP_DIR" "$PROMPT_ALERT"; then
+    check_origin_integrity "$REPO_DIR" "$SNAP_DIR" "$PROMPT_ALERT"
+    local origin_rc=$?
+    if [ "$origin_rc" -eq 1 ]; then
         PROMPT_TAMPERED="${PROMPT_TAMPERED} [ORIGIN MODIFIED]"
+    elif [ "$origin_rc" -eq 2 ]; then
+        PROMPT_TAMPERED="${PROMPT_TAMPERED} [ORIGIN MODIFIED - REVERT FAILED]"
     fi
     cleanup_prompt_snapshots "$SNAP_DIR"
 

--- a/scripts/lib-agent.sh
+++ b/scripts/lib-agent.sh
@@ -36,6 +36,7 @@ PROMPT_GUARD_FILES=(
     "scripts/pick-role.py"
     "scripts/check.sh"
     "scripts/format-stream.py"
+    ".nightshift.json"
     # docs/prompt/healer.md is a reference doc, not a control file (healer merged into builder step)
 )
 
@@ -210,7 +211,9 @@ cleanup_prompt_snapshots() {
 #      snapshot version of each changed file, and force-push the revert to
 #      origin/main so that the subsequent reset_repo_state pulls a clean state.
 #
-# Returns 0 if clean, 1 if tampering was detected (revert attempted).
+# Returns 0 if clean (or PR merge -- legitimate workflow),
+#         1 if tampering detected and revert succeeded,
+#         2 if tampering detected but revert FAILED.
 check_origin_integrity() {
     local repo_dir="$1"
     local snap_dir="$2"
@@ -235,6 +238,18 @@ check_origin_integrity() {
 
     # If hash unchanged, no push occurred during the agent cycle
     if [ -z "$current_hash" ] || [ "$snap_hash" = "$current_hash" ]; then
+        return 0
+    fi
+
+    # Distinguish PR merges from direct pushes.  gh pr merge --merge creates
+    # merge commits (2+ parents).  If every first-parent commit between snap
+    # and current is a merge commit, the changes came through the PR workflow
+    # and should NOT be reverted.  --no-merges excludes merge commits, so an
+    # empty result means all mainline commits are merges.
+    local direct_push_commits
+    direct_push_commits=$(git -C "$repo_dir" rev-list --first-parent --no-merges \
+        "$snap_hash..$current_hash" 2>/dev/null || true)
+    if [ -z "$direct_push_commits" ]; then
         return 0
     fi
 
@@ -290,6 +305,7 @@ check_origin_integrity() {
                 echo "  Reverted origin/main to pre-session state."
             else
                 echo "  WARNING: Revert push failed -- origin/main may still contain tampered files."
+                revert_failed=1
             fi
         else
             echo "  WARNING: Could not restore snapshot files -- revert push skipped."
@@ -310,7 +326,12 @@ check_origin_integrity() {
         fi
     fi
 
-    return "$changed"
+    if [ "$changed" -ne 0 ]; then
+        # 1 = tampered + reverted OK, 2 = tampered + revert failed
+        [ "$revert_failed" -ne 0 ] && return 2
+        return 1
+    fi
+    return 0
 }
 
 # ----------------------------------------------


### PR DESCRIPTION
## Summary
- Breaks the bootstrap self-revert loop: `check_origin_integrity` now skips when all first-parent commits between snapshot and current are merge commits (PR workflow)
- Adds `.nightshift.json` to `PROMPT_GUARD_FILES` (restores SSRF protection from reverted PR #140)
- Returns exit code 2 when revert push fails (was always 1), daemon.sh handles all 3 codes

## Root cause
The guard couldn't distinguish `gh pr merge --merge` (creates merge commits with 2+ parents) from direct pushes (single parent). It reverted PR #140 and #142's security fixes, causing the 3 test failures on main.

## Test plan
- [x] `make check` — 1012 passed, 0 failed
- [ ] Verify daemon runs without self-reverting after PR merges