### PR TITLE
triage: narrow queue follow-up tasks

### DIFF
--- a/.recursive/tasks/0225.md
+++ b/.recursive/tasks/0225.md
@@ -11,19 +11,16 @@ completed:
 
 ## Problem
 
-Each session the security/audit agents find issues and create follow-up tasks. The queue went from 70 to 76 pending across 7 sessions. Tasks created > tasks completed = queue grows forever.
-
-The brain never delegates the oversee agent to triage and cull the queue. Duplicate, low-value, and superseded tasks accumulate.
+Dashboard and role scoring already track queue trend, and overseer delegation has started happening again. The remaining gap is that follow-up task generation is still too loose, so a noisy session can still outpace completion.
 
 ## Fix
 
-1. Brain should track net task delta per session (created - completed)
-2. If net delta > 0 for 3 consecutive sessions, delegate oversee
-3. Sub-agents should be limited: max 2 new tasks per session unless security-critical
-4. Oversee agent should aggressively close duplicates and low-value tasks
+1. Add a hard follow-up-task budget to the brain/build delegation flow.
+2. Limit non-security follow-up creation to 0-2 tasks per session.
+3. Require the generator to check current active-task count before minting more work.
 
 ## Acceptance Criteria
 
-- Dashboard shows task queue trend (growing/shrinking/stable)
-- Brain delegates oversee when queue grows 3 sessions in a row
-- Sub-agents have a task creation limit
+- Task-generation docs or brain prompt state the 0-2 cap
+- New task creation checks active queue size before adding follow-ups
+- Queue trend stays visible so overseer can spot regressions

--- a/.recursive/tasks/0228.md
+++ b/.recursive/tasks/0228.md
@@ -1,13 +1,15 @@
 ---
-status: pending
+status: done
 priority: normal
 target:
 created: 2026-04-08
 source: github-issue-209
-completed:
+completed: 2026-04-09
 ---
 
 # Brain never re-runs eval after building nightshift
+
+Superseded by #0242. The dashboard now exposes `sessions_since_eval`, the brain prompt has the eval cadence rule, and eval reruns have already happened in sessions #0125, #0132, #0134, and #0138.
 
 ## Problem
 


### PR DESCRIPTION
## Summary\n- Closed #0228 as a superseded duplicate of the already-landed eval cadence work in #0242.\n- Narrowed #0225 to the one remaining queue-budget gap: follow-up task generation limits.\n\n## Queue delta\n- Before: 65 pending\n- After: 64 pending\n\n## Files changed\n- .recursive/tasks/0225.md\n- .recursive/tasks/0228.md\n\n## Verification\n- make check\n- Passed cleanly